### PR TITLE
feat!: Explicitly handle status code errors.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,7 @@ use bitcoin::{
 };
 use reqwest::{
     header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE},
-    Client as ReqwestClient, StatusCode,
+    Client as ReqwestClient,
 };
 use serde::{de, Deserialize, Serialize};
 use serde_json::{
@@ -165,6 +165,23 @@ impl Client {
             trace!(?response, "Response received");
             match response {
                 Ok(resp) => {
+                    // Check HTTP status code first before parsing body
+                    let resp = match resp.error_for_status() {
+                        Err(e) if e.is_status() => {
+                            if let Some(status) = e.status() {
+                                let reason =
+                                    status.canonical_reason().unwrap_or("Unknown").to_string();
+                                return Err(ClientError::Status(status.as_u16(), reason));
+                            } else {
+                                return Err(ClientError::Other(e.to_string()));
+                            }
+                        }
+                        Err(e) => {
+                            return Err(ClientError::Other(e.to_string()));
+                        }
+                        Ok(resp) => resp,
+                    };
+
                     let raw_response = resp
                         .text()
                         .await
@@ -946,5 +963,38 @@ mod test {
             .unwrap();
         assert_eq!(result.tx_results.len(), 2);
         assert_eq!(result.package_msg, "success");
+    }
+
+    #[tokio::test]
+    async fn test_invalid_credentials_return_401_error() {
+        init_tracing();
+
+        let (bitcoind, _) = get_bitcoind_and_client();
+        let url = bitcoind.rpc_url();
+
+        // Create client with invalid credentials
+        let invalid_client = Client::new(
+            url,
+            "wrong_user".to_string(),
+            "wrong_password".to_string(),
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Try to make any RPC call
+        let result = invalid_client.get_blockchain_info().await;
+
+        // Verify we get a 401 Status error, not a Parse error
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+
+        match error {
+            ClientError::Status(status_code, message) => {
+                assert_eq!(status_code, 401);
+                assert!(message.contains("Unauthorized"));
+            }
+            _ => panic!("Expected Status(401, _) error, but got: {error:?}"),
+        }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,7 @@ use bitcoin::{
 };
 use reqwest::{
     header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE},
-    Client as ReqwestClient,
+    Client as ReqwestClient, StatusCode,
 };
 use serde::{de, Deserialize, Serialize};
 use serde_json::{
@@ -188,7 +188,7 @@ impl Client {
                     } else if err.is_status() {
                         // Status error is unrecoverable
                         let e = match err.status() {
-                            Some(code) => ClientError::Status(code.to_string(), err.to_string()),
+                            Some(code) => ClientError::Status(code.as_u16(), err.to_string()),
                             _ => ClientError::Other(err.to_string()),
                         };
                         return Err(e);

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,8 +36,9 @@ pub enum ClientError {
     Body(String),
 
     /// HTTP status error, not retryable
+    // NOTE: Using u16 instead of reqwest::StatusCode because StatusCode doesn't implement Serialize/Deserialize
     #[error("Obtained failure status({0}): {1}")]
-    Status(String, String),
+    Status(u16, String),
 
     /// Error decoding the response, retry might not help
     #[error("Malformed Response: {0}")]


### PR DESCRIPTION
## Description

- Changes the error codes representation as `u16`s instead of `String`s.
- Handles status codes explicit error.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Slightly breaking because of the `String` -> `u16` change in the error variant.

this should be REBASE MERGED!

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #23.
