### PR TITLE
fix!: deprecate get_utxos for list_unspent

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -796,10 +796,13 @@ mod test {
         let got = client.list_transactions(None).await.unwrap();
         assert_eq!(got.len(), 10);
 
-        // get_utxos
+        // list_unspent
         // let's mine one more block
         mine_blocks(&bitcoind, 1, None).unwrap();
-        let got = client.get_utxos().await.unwrap();
+        let got = client
+            .list_unspent(None, None, None, None, None)
+            .await
+            .unwrap();
         assert_eq!(got.len(), 3);
 
         // listdescriptors

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -191,6 +191,10 @@ pub trait Wallet {
 
     /// Gets all Unspent Transaction Outputs (UTXOs) for the underlying Bitcoin
     /// client's wallet.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Does not adhere with bitcoin core RPC naming. Use `list_unspent` instead"
+    )]
     fn get_utxos(&self) -> impl Future<Output = ClientResult<Vec<ListUnspent>>> + Send;
 
     /// Lists transactions in the underlying Bitcoin client's wallet.


### PR DESCRIPTION
## Description

Deprecates `get_utxos` in favor of `list_unspent` to adhere with bitcoin core RPC naming convention.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers



## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
