### PR TITLE
Support calling `getrawmempool` with verbosity

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -34,7 +34,7 @@ use crate::{
     types::{
         CreateRawTransaction, CreateRawTransactionInput, CreateRawTransactionOutput, CreateWallet,
         GetAddressInfo, GetBlockVerbosityOne, GetBlockVerbosityZero, GetBlockchainInfo,
-        GetMempoolInfo, GetNewAddress, GetRawTransactionVerbosityOne,
+        GetMempoolInfo, GetNewAddress, GetRawMempoolVerbose, GetRawTransactionVerbosityOne,
         GetRawTransactionVerbosityZero, GetTransaction, GetTxOut, ImportDescriptor,
         ImportDescriptorResult, ListDescriptors, ListTransactions, ListUnspent,
         ListUnspentQueryOptions, PreviousTransactionOutput, PsbtBumpFee, PsbtBumpFeeOptions,
@@ -332,6 +332,11 @@ impl Reader for Client {
 
     async fn get_raw_mempool(&self) -> ClientResult<Vec<Txid>> {
         self.call::<Vec<Txid>>("getrawmempool", &[]).await
+    }
+
+    async fn get_raw_mempool_verbose(&self) -> ClientResult<GetRawMempoolVerbose> {
+        self.call::<GetRawMempoolVerbose>("getrawmempool", &[to_value(true)?])
+            .await
     }
 
     async fn get_mempool_info(&self) -> ClientResult<GetMempoolInfo> {
@@ -756,6 +761,11 @@ mod test {
         let got = client.get_raw_mempool().await.unwrap();
         let expected = vec![txid];
         assert_eq!(expected, got);
+
+        // get_raw_mempool_verbose
+        let got = client.get_raw_mempool_verbose().await.unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got.get(&txid).unwrap().height, 101);
 
         // get_mempool_info
         let got = client.get_mempool_info().await.unwrap();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,12 +5,12 @@ use crate::{
     client::ClientResult,
     types::{
         CreateRawTransaction, CreateRawTransactionInput, CreateRawTransactionOutput,
-        GetAddressInfo, GetBlockchainInfo, GetMempoolInfo, GetRawTransactionVerbosityOne,
-        GetRawTransactionVerbosityZero, GetTransaction, GetTxOut, ImportDescriptor,
-        ImportDescriptorResult, ListTransactions, ListUnspent, ListUnspentQueryOptions,
-        PreviousTransactionOutput, PsbtBumpFee, PsbtBumpFeeOptions, SignRawTransactionWithWallet,
-        SubmitPackage, TestMempoolAccept, WalletCreateFundedPsbt, WalletCreateFundedPsbtOptions,
-        WalletProcessPsbtResult,
+        GetAddressInfo, GetBlockchainInfo, GetMempoolInfo, GetRawMempoolVerbose,
+        GetRawTransactionVerbosityOne, GetRawTransactionVerbosityZero, GetTransaction, GetTxOut,
+        ImportDescriptor, ImportDescriptorResult, ListTransactions, ListUnspent,
+        ListUnspentQueryOptions, PreviousTransactionOutput, PsbtBumpFee, PsbtBumpFeeOptions,
+        SignRawTransactionWithWallet, SubmitPackage, TestMempoolAccept, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtOptions, WalletProcessPsbtResult,
     },
 };
 
@@ -87,6 +87,11 @@ pub trait Reader {
 
     /// Gets all transaction ids in mempool.
     fn get_raw_mempool(&self) -> impl Future<Output = ClientResult<Vec<Txid>>> + Send;
+
+    /// Gets verbose representation of transactions in mempool.
+    fn get_raw_mempool_verbose(
+        &self,
+    ) -> impl Future<Output = ClientResult<GetRawMempoolVerbose>> + Send;
 
     /// Returns details on the active state of the mempool.
     fn get_mempool_info(&self) -> impl Future<Output = ClientResult<GetMempoolInfo>> + Send;

--- a/src/types.rs
+++ b/src/types.rs
@@ -196,6 +196,43 @@ pub struct GetMempoolInfo {
     pub unbroadcastcount: usize,
 }
 
+/// Response from `getrawmempool` with `verbose=true`.
+///
+/// The top-level map key is the txid, and the value contains detailed mempool info per tx.
+pub type GetRawMempoolVerbose = BTreeMap<Txid, MempoolEntry>;
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct MempoolEntry {
+    pub vsize: usize,
+    pub weight: usize,
+    pub time: u64,
+    pub height: usize,
+    pub descendantcount: usize,
+    pub descendantsize: usize,
+    #[serde(default)]
+    pub ancestorcount: usize,
+    pub ancestorsize: usize,
+    pub wtxid: String,
+    pub fees: Option<MempoolFeeBreakdown>,
+    pub depends: Vec<Txid>,
+    pub spentby: Vec<Txid>,
+    #[serde(rename = "bip125-replaceable")]
+    pub bip125_replaceable: bool,
+    pub unbroadcast: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct MempoolFeeBreakdown {
+    #[serde(deserialize_with = "deserialize_bitcoin")]
+    pub base: Amount,
+    #[serde(deserialize_with = "deserialize_bitcoin")]
+    pub modified: Amount,
+    #[serde(deserialize_with = "deserialize_bitcoin")]
+    pub ancestor: Amount,
+    #[serde(deserialize_with = "deserialize_bitcoin")]
+    pub descendant: Amount,
+}
+
 /// Result of JSON-RPC method `getrawtransaction` with verbosity set to 1.
 ///
 /// Method call: `getrawtransaction "txid" ( verbosity )`


### PR DESCRIPTION
## Description

Adds support for calling [getrawmempool](https://developer.bitcoin.org/reference/rpc/getrawmempool.html) with verbosity turned on.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [X] I have performed a self-review of my code.
- [X] I have commented my code where necessary.
- [X] I have updated the documentation if needed.
- [X] My changes do not introduce new warnings.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
