### PR TITLE
[feature] add public call_raw method to Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ keywords = ["crypto", "bitcoin"]
 [features]
 default = ["29_0"]
 29_0 = []
+raw_rpc = []
 
 [dependencies]
 base64 = "0.22.1"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -226,6 +226,7 @@ impl Client {
         }
     }
 
+    #[cfg(feature = "raw_rpc")]
     /// Low-level RPC call wrapper; sends raw params and returns the deserialized result.
     pub async fn call_raw<R: de::DeserializeOwned + fmt::Debug>(
         &self,

--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -1115,6 +1115,7 @@ mod test {
         );
     }
 
+    #[cfg(feature = "raw_rpc")]
     #[tokio::test]
     async fn call_raw() {
         init_tracing();


### PR DESCRIPTION
Im using this in my fork for a project which has custom bitcoin rpc's and thought it might be helpful here. <3

It exposes the internal JSON-RPC calling logic via a new public call_raw method.

This allows users to invoke arbitrary RPC commands even if a strongly-typed wrapper has not yet been implemented in the library.

