### PR TITLE
feat(client): Add optional `timeout` parameter to `Client::new`

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -30,6 +30,9 @@ const DEFAULT_MAX_RETRIES: u8 = 3;
 /// The maximum number of retries for a request.
 const DEFAULT_RETRY_INTERVAL_MS: u64 = 1_000;
 
+/// The timeout for a request in seconds.
+const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
+
 /// Custom implementation to convert a value to a `Value` type.
 pub fn to_value<T>(value: T) -> ClientResult<Value>
 where
@@ -78,6 +81,7 @@ impl Client {
         password: String,
         max_retries: Option<u8>,
         retry_interval: Option<u64>,
+        timeout: Option<u64>,
     ) -> ClientResult<Self> {
         if username.is_empty() || password.is_empty() {
             return Err(ClientError::MissingUserPassword);
@@ -98,6 +102,9 @@ impl Client {
 
         let client = ReqwestClient::builder()
             .default_headers(headers)
+            .timeout(Duration::from_secs(
+                timeout.unwrap_or(DEFAULT_TIMEOUT_SECONDS),
+            ))
             .build()
             .map_err(|e| ClientError::Other(format!("Could not create client: {e}")))?;
 

--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -1018,6 +1018,7 @@ mod test {
             "wrong_password".to_string(),
             None,
             None,
+            None,
         )
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! ```rust,ignore
 //! use bitcoind_async_client::Client;
 //!
-//! let client = Client::new("http://localhost:8332".to_string(), "username".to_string(), "password".to_string(), None, None).await?;
+//! let client = Client::new("http://localhost:8332".to_string(), "username".to_string(), "password".to_string(), None, None, None).await?;
 //!
 //! let blockchain_info = client.get_blockchain_info().await?;
 //! ```

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -44,7 +44,7 @@ pub mod corepc_node_helpers {
 
         let url = bitcoind.rpc_url();
         let (user, password) = get_auth(&bitcoind);
-        let client = Client::new(url, user, password, None, None).unwrap();
+        let client = Client::new(url, user, password, None, None, None).unwrap();
         (bitcoind, client)
     }
 }


### PR DESCRIPTION
Extend the `Client` constructor to support an optional timeout
parameter. This allows users to specify a custom request timeout
duration, improving flexibility and control over network requests.
The default timeout is set to 30 seconds if not explicitly provided.