### PR TITLE
feat(client): Update block header method and add header retrieval test

### DIFF
--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -10,7 +10,7 @@ use bitcoin::{
 };
 use corepc_types::model;
 use corepc_types::v29::{
-    CreateWallet, GetAddressInfo, GetBlockHeaderVerbose, GetBlockVerboseOne, GetBlockVerboseZero,
+    CreateWallet, GetAddressInfo, GetBlockHeader, GetBlockVerboseOne, GetBlockVerboseZero,
     GetBlockchainInfo, GetMempoolInfo, GetNewAddress, GetRawMempool, GetRawMempoolVerbose,
     GetRawTransaction, GetRawTransactionVerbose, GetTransaction, GetTxOut, ImportDescriptors,
     ListDescriptors, ListTransactions, ListUnspent, PsbtBumpFee, SignRawTransactionWithWallet,
@@ -64,7 +64,7 @@ impl Reader for Client {
 
     async fn get_block_header(&self, hash: &BlockHash) -> ClientResult<Header> {
         let get_block_header = self
-            .call::<GetBlockHeaderVerbose>(
+            .call::<GetBlockHeader>(
                 "getblockheader",
                 &[to_value(hash.to_string())?, to_value(false)?],
             )
@@ -568,6 +568,12 @@ mod test {
         let expected = blocks.last().unwrap();
         let got = client.get_block_hash(target_height).await.unwrap();
         assert_eq!(*expected, got);
+
+        // get_block_header_at
+        let target_height = blocks.len() as u64;
+        let expected = blocks.last().unwrap();
+        let got = client.get_block_header_at(target_height).await.unwrap();
+        assert_eq!(*expected, got.block_hash());
 
         // get_new_address
         let address = client.get_new_address().await.unwrap();


### PR DESCRIPTION
## Description

Due to a bug in `GetBlockHeaderVerbose` to extract the `Header` from the JSON, as a TODO, switching to `GetBlockHeader` without the `Verbose` fixes this. 

See https://github.com/rust-bitcoin/corepc/blob/0e9470990ab3eceff01b9496316a1617547d1d6e/types/src/v29/blockchain/into.rs#L169-L170

