### PR TITLE
fix(deps): pin bitreq 0.3.4 and cover idle keep-alive socket recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ base64 = "0.22.1"
 bitcoin = { version = "0.32.8", features = ["serde", "base64"] }
 corepc-types = "0.10.1" # keep in sync with corepc-node
 hex = { package = "hex-conservative", version = "0.2.1" } # for optimization keep in sync with bitcoin
-bitreq = { version = "0.3", default-features = false, features = ["async-https"] }
+bitreq = { version = "0.3.4", default-features = false, features = ["async-https"] }
 secp256k1 = { version = "0.29.1", features = [ # for optimization keep in sync with bitcoin
   "global-context",
 ] }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -298,3 +298,122 @@ impl Client {
         self.call::<R>(method, params).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+        sync::oneshot,
+        time::{sleep, timeout},
+    };
+
+    use super::*;
+
+    async fn read_http_request(stream: &mut TcpStream) {
+        let mut buf = vec![0u8; 4096];
+        let mut total = Vec::new();
+        loop {
+            let n = stream.read(&mut buf).await.expect("read request");
+            if n == 0 {
+                break;
+            }
+            total.extend_from_slice(&buf[..n]);
+            let Some(hdr_end) = total.windows(4).position(|w| w == b"\r\n\r\n") else {
+                continue;
+            };
+            let headers = std::str::from_utf8(&total[..hdr_end]).unwrap_or("");
+            let cl: usize = headers
+                .lines()
+                .find_map(|l| {
+                    let mut parts = l.splitn(2, ':');
+                    let k = parts.next()?.trim();
+                    if k.eq_ignore_ascii_case("Content-Length") {
+                        parts.next()?.trim().parse().ok()
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(0);
+            if total.len() >= hdr_end + 4 + cl {
+                break;
+            }
+        }
+    }
+
+    async fn write_json_response(stream: &mut TcpStream, body: &str) {
+        let response = format!(
+            concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "Content-Type: application/json\r\n",
+                "Connection: keep-alive\r\n",
+                "Content-Length: {}\r\n\r\n{}"
+            ),
+            body.len(),
+            body,
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response");
+        stream.flush().await.expect("flush response");
+    }
+
+    /// Regression test for issue #101: a pooled keep-alive socket that is later
+    /// closed server-side must not permanently poison future RPC calls.
+    #[tokio::test]
+    async fn retry_recovers_from_dead_pooled_connection() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut first_stream, _) = listener.accept().await.expect("accept 1");
+            read_http_request(&mut first_stream).await;
+            write_json_response(
+                &mut first_stream,
+                r#"{"result":"first","error":null,"id":0}"#,
+            )
+            .await;
+
+            // Keep the socket alive long enough for the client to cache it, then
+            // close it server-side to mimic bitcoind's rpcservertimeout behavior.
+            sleep(Duration::from_millis(100)).await;
+            drop(first_stream);
+            let _ = ready_tx.send(());
+
+            let (mut second_stream, _) = listener.accept().await.expect("accept 2");
+            read_http_request(&mut second_stream).await;
+            write_json_response(
+                &mut second_stream,
+                r#"{"result":"second","error":null,"id":1}"#,
+            )
+            .await;
+        });
+
+        let url = format!("http://{}", addr);
+        let client = Client::new(
+            url,
+            Auth::UserPass("user".into(), "pass".into()),
+            Some(3),
+            Some(10),
+            Some(5),
+        )
+        .expect("client");
+
+        let first: String = client.call("ping", &[]).await.expect("first call");
+        assert_eq!(first, "first");
+
+        ready_rx.await.expect("ready signal");
+
+        let second: String = timeout(Duration::from_secs(5), client.call("ping", &[]))
+            .await
+            .expect("call did not time out")
+            .expect("second call");
+        assert_eq!(second, "second");
+
+        server.await.expect("server task");
+    }
+}


### PR DESCRIPTION
## Description

Require `bitreq` 0.3.4 and add a regression test covering the issue #101 scenario where a pooled keep-alive socket is later closed by the server.

The intent here is to avoid carrying a local `BitreqClient` reset workaround in this crate and instead:
- rely on the recovery behavior observed in `bitreq` 0.3.4
- lock that minimum version in `Cargo.toml`
- keep a regression test for the `rpcservertimeout`-style idle socket close case

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

This PR intentionally does not add a local pool-reset workaround.

I checked the reported issue scenario against `bitreq` 0.3.4 and could not reproduce the permanent poisoned-pool behavior described in #101. The new test keeps a connection alive long enough to be pooled, then closes it server-side and verifies the next RPC still succeeds.

This also keeps us aligned with the upstream direction in https://github.com/rust-bitcoin/corepc/pull/564 rather than adding extra client-side complexity here.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Related to #101. https://github.com/rust-bitcoin/corepc/pull/564 with a `bitreq` published version bump here would be the one to fix #101.