### PR TITLE
fix: split Bitcoin RPC error helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-async-client"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind-async-client"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 authors = [
   "Jose Storopoli <jose@alpenlabs.io>",

--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -218,11 +218,10 @@ impl Broadcaster for Client {
                 trace!(?txid, "Transaction sent");
                 Ok(txid)
             }
-            Err(ClientError::Server(i, s)) => match i {
-                // Dealing with known and common errors
-                -27 => Ok(tx.compute_txid()), // Tx already in chain
-                _ => Err(ClientError::Server(i, s)),
-            },
+            Err(err @ ClientError::Server(_, _)) if err.is_rpc_verify_already_in_utxo_set() => {
+                Ok(tx.compute_txid())
+            }
+            Err(err @ ClientError::Server(_, _)) => Err(err),
             Err(e) => Err(ClientError::Other(e.to_string())),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,16 @@ use serde::{Deserialize, Serialize};
 use serde_json::Error as SerdeJsonError;
 use thiserror::Error;
 
+/// Bitcoin Core `RPC_VERIFY_ERROR`, defined in
+/// <https://github.com/bitcoin/bitcoin/blob/8f4a3ba8972dae9412ba975a040cea22c227f983/src/rpc/protocol.h#L47>.
+const RPC_VERIFY_ERROR: i32 = -25;
+/// Bitcoin Core `RPC_VERIFY_REJECTED`, defined in
+/// <https://github.com/bitcoin/bitcoin/blob/8f4a3ba8972dae9412ba975a040cea22c227f983/src/rpc/protocol.h#L48>.
+const RPC_VERIFY_REJECTED: i32 = -26;
+/// Bitcoin Core `RPC_VERIFY_ALREADY_IN_UTXO_SET`, defined in
+/// <https://github.com/bitcoin/bitcoin/blob/8f4a3ba8972dae9412ba975a040cea22c227f983/src/rpc/protocol.h#L49>.
+const RPC_VERIFY_ALREADY_IN_UTXO_SET: i32 = -27;
+
 /// The error type for errors produced in this library.
 #[derive(Error, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ClientError {
@@ -25,6 +35,7 @@ pub enum ClientError {
     #[error("RPC server returned error '{1}' (code {0})")]
     Server(i32, String),
 
+    /// Error parsing the RPC response, unlikely to be recoverable by retrying
     #[error("Error parsing rpc response: {0}")]
     Parse(String),
 
@@ -90,16 +101,44 @@ pub enum ClientError {
 }
 
 impl ClientError {
+    /// Returns `true` when the RPC server reports an invalid address, key, or missing
+    /// transaction/block identifier (`RPC_INVALID_ADDRESS_OR_KEY`, code `-5`).
     pub fn is_tx_not_found(&self) -> bool {
         matches!(self, Self::Server(-5, _))
     }
 
+    /// Returns `true` when the RPC server reports an invalid address, key, or missing
+    /// transaction/block identifier (`RPC_INVALID_ADDRESS_OR_KEY`, code `-5`).
     pub fn is_block_not_found(&self) -> bool {
         matches!(self, Self::Server(-5, _))
     }
 
+    /// Returns `true` when the RPC server reports a general transaction or block
+    /// submission verification error (`RPC_VERIFY_ERROR`, code `-25`).
+    pub fn is_rpc_verify_error(&self) -> bool {
+        matches!(self, Self::Server(RPC_VERIFY_ERROR, _))
+    }
+
+    /// Returns `true` when the RPC server reports a transaction or block rejected
+    /// by network rules (`RPC_VERIFY_REJECTED`, code `-26`).
+    pub fn is_rpc_verify_rejected(&self) -> bool {
+        matches!(self, Self::Server(RPC_VERIFY_REJECTED, _))
+    }
+
+    /// Returns `true` when the RPC server reports a transaction already present in
+    /// the UTXO set (`RPC_VERIFY_ALREADY_IN_UTXO_SET`, code `-27`).
+    pub fn is_rpc_verify_already_in_utxo_set(&self) -> bool {
+        matches!(self, Self::Server(RPC_VERIFY_ALREADY_IN_UTXO_SET, _))
+    }
+
+    /// Returns `true` when the RPC server reports missing or invalid transaction
+    /// inputs (`RPC_VERIFY_ERROR`, code `-25`).
+    #[deprecated(
+        since = "0.10.4",
+        note = "use is_rpc_verify_error() to detect RPC_VERIFY_ERROR (-25)"
+    )]
     pub fn is_missing_or_invalid_input(&self) -> bool {
-        matches!(self, Self::Server(-26, _)) || matches!(self, Self::Server(-25, _))
+        self.is_rpc_verify_error()
     }
 }
 
@@ -206,5 +245,52 @@ impl fmt::Display for UnexpectedServerVersionError {
             "unexpected bitcoind version, got: {} expected one of: {}",
             self.got, expected
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(deprecated)]
+
+    use super::ClientError;
+
+    #[test]
+    fn classifies_rpc_verify_error() {
+        let error = ClientError::Server(-25, "Input not found or already spent".to_string());
+
+        assert!(error.is_rpc_verify_error());
+        assert!(error.is_missing_or_invalid_input());
+        assert!(!error.is_rpc_verify_rejected());
+        assert!(!error.is_rpc_verify_already_in_utxo_set());
+    }
+
+    #[test]
+    fn classifies_rpc_verify_rejected() {
+        let error = ClientError::Server(-26, "txn-already-in-mempool".to_string());
+
+        assert!(error.is_rpc_verify_rejected());
+        assert!(!error.is_missing_or_invalid_input());
+        assert!(!error.is_rpc_verify_error());
+        assert!(!error.is_rpc_verify_already_in_utxo_set());
+    }
+
+    #[test]
+    fn classifies_rpc_verify_already_in_utxo_set() {
+        let error = ClientError::Server(-27, "transaction already in block chain".to_string());
+
+        assert!(error.is_rpc_verify_already_in_utxo_set());
+        assert!(!error.is_rpc_verify_error());
+        assert!(!error.is_rpc_verify_rejected());
+        assert!(!error.is_missing_or_invalid_input());
+    }
+
+    #[test]
+    fn non_server_errors_do_not_match_rpc_code_helpers() {
+        let error = ClientError::Timeout;
+
+        assert!(!error.is_rpc_verify_error());
+        assert!(!error.is_rpc_verify_rejected());
+        assert!(!error.is_rpc_verify_already_in_utxo_set());
+        assert!(!error.is_missing_or_invalid_input());
     }
 }


### PR DESCRIPTION
## Summary
- add explicit helpers for Bitcoin Core RPC verify errors -25, -26, and -27
- narrow and deprecate is_missing_or_invalid_input() so it only covers RPC_VERIFY_ERROR (-25)
- bump crate version to 0.10.4 for a patch release

## Tests
- cargo test