### PR TITLE
fix(deps): keep 0.10.5 compatible with Alpen Reth pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,12 +114,12 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-async-client"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bitcoin",
- "bitreq 0.3.5",
+ "bitreq 0.3.4",
  "corepc-node",
  "corepc-types",
  "hex-conservative",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "bitreq"
-version = "0.3.5"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df90cd78f0510165fd370574676aeb57dbec0ee3bfff68645bb7b0e9a65dbd5"
+checksum = "08221cf31c5f00fb6fc8fa697cea54176b06801a518bd9d3482aa27099827a3a"
 dependencies = [
  "rustls",
  "rustls-webpki",
@@ -231,7 +231,7 @@ checksum = "2f8749105873c391b77fc943b7fdf8c05b6c1d06f6e71c6d2746ee7f8bda0072"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
- "bitreq 0.3.5",
+ "bitreq 0.3.4",
  "corepc-client",
  "flate2",
  "log",
@@ -527,35 +527,32 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
- "once_cell",
  "ring",
- "rustls-pki-types",
  "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
-dependencies = [
- "zeroize",
+ "sct",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
  "untrusted",
 ]
 
@@ -660,12 +657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
@@ -839,12 +830,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
-]
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"
@@ -1026,12 +1014,6 @@ dependencies = [
  "libc",
  "rustix",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind-async-client"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2021"
 authors = [
   "Jose Storopoli <jose@alpenlabs.io>",
@@ -28,7 +28,7 @@ base64 = "0.22.1"
 bitcoin = { version = "0.32.8", features = ["serde", "base64"] }
 corepc-types = "0.12.0" # keep in sync with corepc-node
 hex = { package = "hex-conservative", version = "0.2.1" } # for optimization keep in sync with bitcoin
-bitreq = { version = "0.3.5", default-features = false, features = ["async-https"] }
+bitreq = { version = ">=0.3.4, <0.3.5", default-features = false, features = ["async-https"] }
 secp256k1 = { version = "0.29.1", features = [ # for optimization keep in sync with bitcoin
   "global-context",
 ] }


### PR DESCRIPTION
## Summary

Prepare `bitcoind-async-client` `0.10.5` as a compatibility release for Alpen.

`0.10.4` includes the RPC error helper fix from #110, but the published crate pins `bitreq = 0.3.5`. That pulls in the newer `rustls 0.23.40` / `aws-lc-sys 0.31` chain, which requires `cc >= 1.2.26` and conflicts with Alpen's current Reth `v1.9.1` dependency pin on `cc = 1.2.15`.

This keeps the `0.10.4` code and bumps the crate to `0.10.5`, while constraining `bitreq` to the existing compatible line:

```toml
bitreq = { version = ">=0.3.4, <0.3.5", default-features = false, features = ["async-https"] }
```

That resolves back to `bitreq 0.3.4` and `rustls 0.21`, matching what Alpen already builds with today.

## Verification

- [x] `cargo test`
- [x] `cargo package --allow-dirty`

## AI Assistance

Dependency debugging and patch preparation.
