### PR TITLE
feat!: make `max_retries` a `u16`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,11 @@ raw_rpc = []
 [dependencies]
 base64 = "0.22.1"
 bitcoin = { version = "0.32.8", features = ["serde", "base64"] }
+bitreq = { version = "0.3.5", default-features = false, features = [
+  "async-https",
+] }
 corepc-types = "0.12.0" # keep in sync with corepc-node
 hex = { package = "hex-conservative", version = "0.2.1" } # for optimization keep in sync with bitcoin
-bitreq = { version = "0.3.5", default-features = false, features = ["async-https"] }
 secp256k1 = { version = "0.29.1", features = [ # for optimization keep in sync with bitcoin
   "global-context",
 ] }
@@ -40,7 +42,10 @@ tracing = { version = "0.1.41", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.102"
-corepc-node = { version = "0.12.0", features = ["29_0", "download"] } # keep in sync with corepc-types
+corepc-node = { version = "0.12.0", features = [
+  "29_0",
+  "download",
+] } # keep in sync with corepc-types
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [profile.release]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -25,7 +25,7 @@ pub mod v29;
 pub type ClientResult<T> = Result<T, ClientError>;
 
 /// The maximum number of retries for a request.
-const DEFAULT_MAX_RETRIES: u8 = 3;
+const DEFAULT_MAX_RETRIES: u16 = 3;
 
 /// The maximum number of retries for a request.
 const DEFAULT_RETRY_INTERVAL_MS: u64 = 1_000;
@@ -93,7 +93,7 @@ pub struct Client {
     id: Arc<AtomicUsize>,
 
     /// The maximum number of retries for a request.
-    max_retries: u8,
+    max_retries: u16,
 
     /// Interval between retries for a request in ms.
     retry_interval: u64,
@@ -129,7 +129,7 @@ impl Client {
     pub fn new(
         url: String,
         auth: Auth,
-        max_retries: Option<u8>,
+        max_retries: Option<u16>,
         retry_interval: Option<u64>,
         timeout: Option<u64>,
     ) -> ClientResult<Self> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,7 +76,7 @@ pub enum ClientError {
 
     /// Maximum retries exceeded, not retryable
     #[error("Max retries {0} exceeded")]
-    MaxRetriesExceeded(u8),
+    MaxRetriesExceeded(u16),
 
     /// General request error, retry might help
     #[error("Could not create request: {0}")]


### PR DESCRIPTION
## Description

Breaking change. Some users need more than 255 retries (`u8`). Bumping to a `u16` so that it can tolerate up to 65k retries.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

New minor bump after this PR

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
