### PR TITLE
feat!: preserve sub-1 sat/vB fee rates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base58ck"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +129,7 @@ dependencies = [
  "corepc-node",
  "corepc-types 0.13.0",
  "hex-conservative",
+ "proptest",
  "secp256k1",
  "serde",
  "serde_json",
@@ -134,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitreq"
@@ -335,6 +342,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "hex-conservative"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +467,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +494,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,12 +512,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -517,7 +613,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -825,6 +921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +949,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "webpki-roots"
@@ -1029,6 +1140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1153,26 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ anyhow = "1.0.102"
 corepc-node = { version = "0.12.0", features = [
   "download",
 ] } # try keep in sync with corepc-types
+proptest = { version = "1.11.0", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [profile.release]

--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -467,10 +467,13 @@ impl Signer for Client {
 #[cfg(test)]
 mod test {
 
-    use std::sync::Once;
+    use std::{env, sync::Once, time::Duration};
 
     use bitcoin::{hashes::Hash, transaction, Amount, FeeRate, NetworkKind};
+    use corepc_node::{Conf, Node, P2P};
     use corepc_types::v29::ImportDescriptorsResult;
+    use serde_json::Value;
+    use tokio::time::sleep;
     use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
     use super::*;
@@ -483,6 +486,21 @@ mod test {
     /// 50 BTC in [`Network::Regtest`].
     const COINBASE_AMOUNT: Amount = Amount::from_sat(50 * 100_000_000);
 
+    /// Number of confirmation rounds needed for Bitcoin Core to produce a fee estimate on regtest.
+    const FEE_ESTIMATION_BLOCKS: usize = 5;
+
+    /// Number of relayed transactions included in each fee-estimation training block.
+    const FEE_ESTIMATION_TXS_PER_BLOCK: usize = 5;
+
+    /// Fee rate used for the transactions that train Bitcoin Core's fee estimator.
+    const FEE_ESTIMATION_FEE_RATE: FeeRate = FeeRate::from_sat_per_kwu(500);
+
+    /// Maximum polling attempts while waiting for regtest P2P relay/validation in CI.
+    const FEE_ESTIMATION_WAIT_ATTEMPTS: usize = 1_200;
+
+    /// Polling interval for fee-estimation setup waits.
+    const FEE_ESTIMATION_WAIT_INTERVAL: Duration = Duration::from_millis(50);
+
     /// Only attempts to start tracing once.
     fn init_tracing() {
         static INIT: Once = Once::new();
@@ -494,6 +512,96 @@ mod test {
                 .try_init()
                 .ok();
         });
+    }
+
+    /// Starts two P2P-connected regtest nodes and returns a client for the node under test.
+    fn get_p2p_bitcoind_and_client() -> (Node, Node, Client) {
+        unsafe {
+            env::set_var("BITCOIN_XPRIV_RETRIEVABLE", "true");
+        }
+
+        let mut estimator_conf = Conf::default();
+        estimator_conf.args.push("-txindex=1");
+        estimator_conf.p2p = P2P::Yes;
+        let estimator = Node::from_downloaded_with_conf(&estimator_conf).unwrap();
+
+        let mut broadcaster_conf = Conf::default();
+        broadcaster_conf.args.push("-txindex=1");
+        broadcaster_conf.p2p = estimator.p2p_connect(false).unwrap();
+        let broadcaster = Node::from_downloaded_with_conf(&broadcaster_conf).unwrap();
+
+        let client = Client::new(
+            estimator.rpc_url(),
+            Auth::CookieFile(estimator.params.cookie_file.clone()),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        (estimator, broadcaster, client)
+    }
+
+    /// Waits until the async client observes the expected block height.
+    async fn wait_for_block_count(client: &Client, expected: u64) {
+        for _ in 0..FEE_ESTIMATION_WAIT_ATTEMPTS {
+            if client.get_block_count().await.unwrap() == expected {
+                return;
+            }
+            sleep(FEE_ESTIMATION_WAIT_INTERVAL).await;
+        }
+        panic!("timed out waiting for block height {expected}");
+    }
+
+    /// Waits until the async client observes at least the expected number of mempool transactions.
+    async fn wait_for_mempool_len(client: &Client, expected: usize) {
+        for _ in 0..FEE_ESTIMATION_WAIT_ATTEMPTS {
+            if client.get_raw_mempool().await.unwrap().0.len() >= expected {
+                return;
+            }
+            sleep(FEE_ESTIMATION_WAIT_INTERVAL).await;
+        }
+        panic!("timed out waiting for {expected} transactions in mempool");
+    }
+
+    /// Builds enough observed relay-and-confirmation history for `estimatesmartfee` to return a fee rate.
+    async fn populate_fee_estimation_history(
+        estimator: &Node,
+        broadcaster: &Node,
+        estimator_client: &Client,
+    ) {
+        let funding_address = broadcaster.client.new_address().unwrap();
+        mine_blocks(broadcaster, 101, Some(funding_address)).unwrap();
+        wait_for_block_count(estimator_client, 101).await;
+
+        for _ in 0..FEE_ESTIMATION_BLOCKS {
+            for _ in 0..FEE_ESTIMATION_TXS_PER_BLOCK {
+                let address = broadcaster.client.new_address().unwrap();
+                let txid = broadcaster
+                    .client
+                    .call::<String>(
+                        "sendtoaddress",
+                        &[
+                            to_value(address.to_string()).unwrap(),
+                            to_value(0.1).unwrap(),
+                            to_value("").unwrap(),
+                            to_value("").unwrap(),
+                            to_value(false).unwrap(),
+                            to_value(true).unwrap(),
+                            Value::Null,
+                            to_value("unset").unwrap(),
+                            Value::Null,
+                            to_value(FEE_ESTIMATION_FEE_RATE.to_sat_per_kwu() as f64 / 250.0)
+                                .unwrap(),
+                        ],
+                    )
+                    .unwrap();
+                txid.parse::<Txid>().unwrap();
+            }
+
+            wait_for_mempool_len(estimator_client, FEE_ESTIMATION_TXS_PER_BLOCK).await;
+            mine_blocks(estimator, 1, None).unwrap();
+        }
     }
 
     #[tokio::test()]
@@ -602,13 +710,6 @@ mod test {
         assert!(got.loaded.unwrap_or(false));
         assert_eq!(got.size, 1);
         assert_eq!(got.unbroadcast_count, Some(1));
-
-        // estimate_smart_fee
-        // On regtest there is no fee-estimation history, so Bitcoin Core returns no `feerate`
-        // and instead populates `errors`.
-        let got = client.estimate_smart_fee(1).await.unwrap();
-        assert!(got.fee_rate.is_none());
-        assert!(got.errors.is_some());
 
         // sign_raw_transaction_with_wallet
         let got = client
@@ -782,6 +883,19 @@ mod test {
         let tx = finalized_psbt.hex.unwrap();
         assert!(!tx.input.is_empty());
         assert!(!tx.output.is_empty());
+    }
+
+    #[tokio::test()]
+    async fn estimate_smart_fee_returns_fee_rate_after_observed_regtest_history() {
+        init_tracing();
+
+        let (estimator, broadcaster, client) = get_p2p_bitcoind_and_client();
+        populate_fee_estimation_history(&estimator, &broadcaster, &client).await;
+
+        let got = client.estimate_smart_fee(1).await.unwrap();
+        assert_eq!(got.fee_rate, Some(FEE_ESTIMATION_FEE_RATE));
+        assert!(got.errors.is_none());
+        assert_eq!(got.blocks, 2);
     }
 
     #[tokio::test()]

--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -10,13 +10,13 @@ use bitcoin::{
 };
 use corepc_types::model;
 use corepc_types::v29::{
-    CreateWallet, GetAddressInfo, GetBlockHeader, GetBlockVerboseOne, GetBlockVerboseZero,
-    GetBlockchainInfo, GetMempoolInfo, GetNewAddress, GetRawMempool, GetRawMempoolVerbose,
-    GetRawTransaction, GetRawTransactionVerbose, GetTransaction, GetTxOut, ImportDescriptors,
-    ListDescriptors, ListTransactions, ListUnspent, PsbtBumpFee, SignRawTransactionWithWallet,
-    SubmitPackage, TestMempoolAccept, WalletCreateFundedPsbt, WalletProcessPsbt,
+    CreateWallet, EstimateSmartFee, GetAddressInfo, GetBlockHeader, GetBlockVerboseOne,
+    GetBlockVerboseZero, GetBlockchainInfo, GetMempoolInfo, GetNewAddress, GetRawMempool,
+    GetRawMempoolVerbose, GetRawTransaction, GetRawTransactionVerbose, GetTransaction, GetTxOut,
+    ImportDescriptors, ListDescriptors, ListTransactions, ListUnspent, PsbtBumpFee,
+    SignRawTransactionWithWallet, SubmitPackage, TestMempoolAccept, WalletCreateFundedPsbt,
+    WalletProcessPsbt,
 };
-use serde_json::value::{RawValue, Value};
 use tracing::*;
 
 use crate::{
@@ -32,34 +32,14 @@ use crate::{
     ClientResult,
 };
 
-/// Minimum relay fee rate: 1 sat/vB = 0.00001 BTC/kvB
-const MIN_FEE_RATE_BTC_VKB: f64 = 0.00001;
-
 impl Reader for Client {
-    async fn estimate_smart_fee(&self, conf_target: u16) -> ClientResult<u64> {
-        let result = self
-            .call::<Box<RawValue>>("estimatesmartfee", &[to_value(conf_target)?])
-            .await?
-            .to_string();
+    async fn estimate_smart_fee(&self, conf_target: u16) -> ClientResult<model::EstimateSmartFee> {
+        let resp = self
+            .call::<EstimateSmartFee>("estimatesmartfee", &[to_value(conf_target)?])
+            .await?;
 
-        let result_map: Value = result.parse::<Value>()?;
-
-        let btc_vkb = result_map
-            .get("feerate")
-            .and_then(|v| v.as_f64())
-            .unwrap_or(MIN_FEE_RATE_BTC_VKB); // Default to minimum if missing or invalid
-
-        // Ensure fee rate is positive and non-zero
-        if btc_vkb <= 0.0 {
-            return Err(ClientError::Other(
-                "Invalid fee rate: must be positive".to_string(),
-            ));
-        }
-
-        // Convert BTC/vB to sat/vB
-        let sat_vb = (btc_vkb * 100_000_000.0 / 1_000.0) as u64;
-
-        Ok(sat_vb)
+        resp.into_model()
+            .map_err(|e| ClientError::Parse(e.to_string()))
     }
 
     async fn get_block_header(&self, hash: &BlockHash) -> ClientResult<Header> {
@@ -624,9 +604,11 @@ mod test {
         assert_eq!(got.unbroadcast_count, Some(1));
 
         // estimate_smart_fee
+        // On regtest there is no fee-estimation history, so Bitcoin Core returns no `feerate`
+        // and instead populates `errors`.
         let got = client.estimate_smart_fee(1).await.unwrap();
-        let expected = 1; // 1 sat/vB
-        assert_eq!(expected, got);
+        assert!(got.fee_rate.is_none());
+        assert!(got.errors.is_some());
 
         // sign_raw_transaction_with_wallet
         let got = client

--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -1140,7 +1140,7 @@ mod test {
 
         // Test psbt_bump_fee with custom fee rate
         let options = PsbtBumpFeeOptions {
-            fee_rate: Some(FeeRate::from_sat_per_kwu(20)), // 20 sat/vB - higher than default
+            fee_rate: Some(FeeRate::from_sat_per_vb(20).unwrap()), // 20 sat/vB - higher than default
             ..Default::default()
         };
         trace!(?options, "Calling psbt_bump_fee");

--- a/src/client/v30.rs
+++ b/src/client/v30.rs
@@ -495,6 +495,12 @@ mod test {
     /// Fee rate used for the transactions that train Bitcoin Core's fee estimator.
     const FEE_ESTIMATION_FEE_RATE: FeeRate = FeeRate::from_sat_per_kwu(500);
 
+    /// Maximum polling attempts while waiting for regtest P2P relay/validation in CI.
+    const FEE_ESTIMATION_WAIT_ATTEMPTS: usize = 1_200;
+
+    /// Polling interval for fee-estimation setup waits.
+    const FEE_ESTIMATION_WAIT_INTERVAL: Duration = Duration::from_millis(50);
+
     /// Only attempts to start tracing once.
     fn init_tracing() {
         static INIT: Once = Once::new();
@@ -538,22 +544,22 @@ mod test {
 
     /// Waits until the async client observes the expected block height.
     async fn wait_for_block_count(client: &Client, expected: u64) {
-        for _ in 0..200 {
+        for _ in 0..FEE_ESTIMATION_WAIT_ATTEMPTS {
             if client.get_block_count().await.unwrap() == expected {
                 return;
             }
-            sleep(Duration::from_millis(50)).await;
+            sleep(FEE_ESTIMATION_WAIT_INTERVAL).await;
         }
         panic!("timed out waiting for block height {expected}");
     }
 
     /// Waits until the async client observes at least the expected number of mempool transactions.
     async fn wait_for_mempool_len(client: &Client, expected: usize) {
-        for _ in 0..200 {
+        for _ in 0..FEE_ESTIMATION_WAIT_ATTEMPTS {
             if client.get_raw_mempool().await.unwrap().0.len() >= expected {
                 return;
             }
-            sleep(Duration::from_millis(50)).await;
+            sleep(FEE_ESTIMATION_WAIT_INTERVAL).await;
         }
         panic!("timed out waiting for {expected} transactions in mempool");
     }

--- a/src/client/v30.rs
+++ b/src/client/v30.rs
@@ -10,13 +10,13 @@ use bitcoin::{
 };
 use corepc_types::model;
 use corepc_types::v30::{
-    CreateWallet, GetAddressInfo, GetBlockHeader, GetBlockVerboseOne, GetBlockVerboseZero,
-    GetBlockchainInfo, GetMempoolInfo, GetNewAddress, GetRawMempool, GetRawMempoolVerbose,
-    GetRawTransaction, GetRawTransactionVerbose, GetTransaction, GetTxOut, ImportDescriptors,
-    ListDescriptors, ListTransactions, ListUnspent, PsbtBumpFee, SignRawTransactionWithWallet,
-    SubmitPackage, TestMempoolAccept, WalletCreateFundedPsbt, WalletProcessPsbt,
+    CreateWallet, EstimateSmartFee, GetAddressInfo, GetBlockHeader, GetBlockVerboseOne,
+    GetBlockVerboseZero, GetBlockchainInfo, GetMempoolInfo, GetNewAddress, GetRawMempool,
+    GetRawMempoolVerbose, GetRawTransaction, GetRawTransactionVerbose, GetTransaction, GetTxOut,
+    ImportDescriptors, ListDescriptors, ListTransactions, ListUnspent, PsbtBumpFee,
+    SignRawTransactionWithWallet, SubmitPackage, TestMempoolAccept, WalletCreateFundedPsbt,
+    WalletProcessPsbt,
 };
-use serde_json::value::{RawValue, Value};
 use tracing::*;
 
 use crate::{
@@ -32,34 +32,14 @@ use crate::{
     ClientResult,
 };
 
-/// Minimum relay fee rate: 1 sat/vB = 0.00001 BTC/kvB
-const MIN_FEE_RATE_BTC_VKB: f64 = 0.00001;
-
 impl Reader for Client {
-    async fn estimate_smart_fee(&self, conf_target: u16) -> ClientResult<u64> {
-        let result = self
-            .call::<Box<RawValue>>("estimatesmartfee", &[to_value(conf_target)?])
-            .await?
-            .to_string();
+    async fn estimate_smart_fee(&self, conf_target: u16) -> ClientResult<model::EstimateSmartFee> {
+        let resp = self
+            .call::<EstimateSmartFee>("estimatesmartfee", &[to_value(conf_target)?])
+            .await?;
 
-        let result_map: Value = result.parse::<Value>()?;
-
-        let btc_vkb = result_map
-            .get("feerate")
-            .and_then(|v| v.as_f64())
-            .unwrap_or(MIN_FEE_RATE_BTC_VKB); // Default to minimum if missing or invalid
-
-        // Ensure fee rate is positive and non-zero
-        if btc_vkb <= 0.0 {
-            return Err(ClientError::Other(
-                "Invalid fee rate: must be positive".to_string(),
-            ));
-        }
-
-        // Convert BTC/vB to sat/vB
-        let sat_vb = (btc_vkb * 100_000_000.0 / 1_000.0) as u64;
-
-        Ok(sat_vb)
+        resp.into_model()
+            .map_err(|e| ClientError::Parse(e.to_string()))
     }
 
     async fn get_block_header(&self, hash: &BlockHash) -> ClientResult<Header> {
@@ -487,10 +467,13 @@ impl Signer for Client {
 #[cfg(test)]
 mod test {
 
-    use std::sync::Once;
+    use std::{env, sync::Once, time::Duration};
 
     use bitcoin::{hashes::Hash, transaction, Amount, FeeRate, NetworkKind};
-    use corepc_types::v29::ImportDescriptorsResult;
+    use corepc_node::{Conf, Node, P2P};
+    use corepc_types::v30::ImportDescriptorsResult;
+    use serde_json::Value;
+    use tokio::time::sleep;
     use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
     use super::*;
@@ -503,6 +486,15 @@ mod test {
     /// 50 BTC in [`Network::Regtest`].
     const COINBASE_AMOUNT: Amount = Amount::from_sat(50 * 100_000_000);
 
+    /// Number of confirmation rounds needed for Bitcoin Core to produce a fee estimate on regtest.
+    const FEE_ESTIMATION_BLOCKS: usize = 5;
+
+    /// Number of relayed transactions included in each fee-estimation training block.
+    const FEE_ESTIMATION_TXS_PER_BLOCK: usize = 5;
+
+    /// Fee rate used for the transactions that train Bitcoin Core's fee estimator.
+    const FEE_ESTIMATION_FEE_RATE: FeeRate = FeeRate::from_sat_per_kwu(500);
+
     /// Only attempts to start tracing once.
     fn init_tracing() {
         static INIT: Once = Once::new();
@@ -514,6 +506,96 @@ mod test {
                 .try_init()
                 .ok();
         });
+    }
+
+    /// Starts two P2P-connected regtest nodes and returns a client for the node under test.
+    fn get_p2p_bitcoind_and_client() -> (Node, Node, Client) {
+        unsafe {
+            env::set_var("BITCOIN_XPRIV_RETRIEVABLE", "true");
+        }
+
+        let mut estimator_conf = Conf::default();
+        estimator_conf.args.push("-txindex=1");
+        estimator_conf.p2p = P2P::Yes;
+        let estimator = Node::from_downloaded_with_conf(&estimator_conf).unwrap();
+
+        let mut broadcaster_conf = Conf::default();
+        broadcaster_conf.args.push("-txindex=1");
+        broadcaster_conf.p2p = estimator.p2p_connect(false).unwrap();
+        let broadcaster = Node::from_downloaded_with_conf(&broadcaster_conf).unwrap();
+
+        let client = Client::new(
+            estimator.rpc_url(),
+            Auth::CookieFile(estimator.params.cookie_file.clone()),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        (estimator, broadcaster, client)
+    }
+
+    /// Waits until the async client observes the expected block height.
+    async fn wait_for_block_count(client: &Client, expected: u64) {
+        for _ in 0..200 {
+            if client.get_block_count().await.unwrap() == expected {
+                return;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        panic!("timed out waiting for block height {expected}");
+    }
+
+    /// Waits until the async client observes at least the expected number of mempool transactions.
+    async fn wait_for_mempool_len(client: &Client, expected: usize) {
+        for _ in 0..200 {
+            if client.get_raw_mempool().await.unwrap().0.len() >= expected {
+                return;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        panic!("timed out waiting for {expected} transactions in mempool");
+    }
+
+    /// Builds enough observed relay-and-confirmation history for `estimatesmartfee` to return a fee rate.
+    async fn populate_fee_estimation_history(
+        estimator: &Node,
+        broadcaster: &Node,
+        estimator_client: &Client,
+    ) {
+        let funding_address = broadcaster.client.new_address().unwrap();
+        mine_blocks(broadcaster, 101, Some(funding_address)).unwrap();
+        wait_for_block_count(estimator_client, 101).await;
+
+        for _ in 0..FEE_ESTIMATION_BLOCKS {
+            for _ in 0..FEE_ESTIMATION_TXS_PER_BLOCK {
+                let address = broadcaster.client.new_address().unwrap();
+                let txid = broadcaster
+                    .client
+                    .call::<String>(
+                        "sendtoaddress",
+                        &[
+                            to_value(address.to_string()).unwrap(),
+                            to_value(0.1).unwrap(),
+                            to_value("").unwrap(),
+                            to_value("").unwrap(),
+                            to_value(false).unwrap(),
+                            to_value(true).unwrap(),
+                            Value::Null,
+                            to_value("unset").unwrap(),
+                            Value::Null,
+                            to_value(FEE_ESTIMATION_FEE_RATE.to_sat_per_kwu() as f64 / 250.0)
+                                .unwrap(),
+                        ],
+                    )
+                    .unwrap();
+                txid.parse::<Txid>().unwrap();
+            }
+
+            wait_for_mempool_len(estimator_client, FEE_ESTIMATION_TXS_PER_BLOCK).await;
+            mine_blocks(estimator, 1, None).unwrap();
+        }
     }
 
     #[tokio::test()]
@@ -622,11 +704,6 @@ mod test {
         assert!(got.loaded.unwrap_or(false));
         assert_eq!(got.size, 1);
         assert_eq!(got.unbroadcast_count, Some(1));
-
-        // estimate_smart_fee
-        let got = client.estimate_smart_fee(1).await.unwrap();
-        let expected = 1; // 1 sat/vB
-        assert_eq!(expected, got);
 
         // sign_raw_transaction_with_wallet
         let got = client
@@ -800,6 +877,19 @@ mod test {
         let tx = finalized_psbt.hex.unwrap();
         assert!(!tx.input.is_empty());
         assert!(!tx.output.is_empty());
+    }
+
+    #[tokio::test()]
+    async fn estimate_smart_fee_returns_fee_rate_after_observed_regtest_history() {
+        init_tracing();
+
+        let (estimator, broadcaster, client) = get_p2p_bitcoind_and_client();
+        populate_fee_estimation_history(&estimator, &broadcaster, &client).await;
+
+        let got = client.estimate_smart_fee(1).await.unwrap();
+        assert_eq!(got.fee_rate, Some(FEE_ESTIMATION_FEE_RATE));
+        assert!(got.errors.is_none());
+        assert_eq!(got.blocks, 2);
     }
 
     #[tokio::test()]
@@ -1140,7 +1230,7 @@ mod test {
 
         // Test psbt_bump_fee with custom fee rate
         let options = PsbtBumpFeeOptions {
-            fee_rate: Some(FeeRate::from_sat_per_kwu(20)), // 20 sat/vB - higher than default
+            fee_rate: Some(FeeRate::from_sat_per_vb(20).unwrap()), // 20 sat/vB - higher than default
             ..Default::default()
         };
         trace!(?options, "Calling psbt_bump_fee");

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,9 +1,9 @@
 use bitcoin::{bip32::Xpriv, block::Header, Address, Block, BlockHash, Network, Transaction, Txid};
 use corepc_types::model::{
-    GetAddressInfo, GetBlockchainInfo, GetMempoolInfo, GetRawMempool, GetRawMempoolVerbose,
-    GetRawTransaction, GetRawTransactionVerbose, GetTransaction, GetTxOut, ListTransactions,
-    ListUnspent, PsbtBumpFee, SignRawTransactionWithWallet, SubmitPackage, TestMempoolAccept,
-    WalletCreateFundedPsbt, WalletProcessPsbt,
+    EstimateSmartFee, GetAddressInfo, GetBlockchainInfo, GetMempoolInfo, GetRawMempool,
+    GetRawMempoolVerbose, GetRawTransaction, GetRawTransactionVerbose, GetTransaction, GetTxOut,
+    ListTransactions, ListUnspent, PsbtBumpFee, SignRawTransactionWithWallet, SubmitPackage,
+    TestMempoolAccept, WalletCreateFundedPsbt, WalletProcessPsbt,
 };
 use corepc_types::v29::ImportDescriptors;
 use std::future::Future;
@@ -29,9 +29,9 @@ use crate::{
 /// consider wrapping with [`tokio`](https://tokio.rs)'s
 /// [`spawn_blocking`](https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html) or any other method.
 pub trait Reader {
-    /// Estimates the approximate fee per kilobyte needed for a transaction
-    /// to begin confirmation within conf_target blocks if possible and return
-    /// the number of blocks for which the estimate is valid.
+    /// Estimates the approximate fee rate needed for a transaction to begin
+    /// confirmation within `conf_target` blocks if possible, returning the
+    /// number of blocks for which the estimate is valid.
     ///
     /// # Parameters
     ///
@@ -45,10 +45,15 @@ pub trait Reader {
     ///
     /// By default uses the estimate mode of `CONSERVATIVE` which is the
     /// default in Bitcoin Core v27.
+    ///
+    /// The returned [`EstimateSmartFee::fee_rate`] is a [`bitcoin::FeeRate`],
+    /// which can represent sub-1 sat/vB rates. It is `None` (with
+    /// [`EstimateSmartFee::errors`] populated) when Bitcoin Core has
+    /// insufficient data to produce an estimate.
     fn estimate_smart_fee(
         &self,
         conf_target: u16,
-    ) -> impl Future<Output = ClientResult<u64>> + Send;
+    ) -> impl Future<Output = ClientResult<EstimateSmartFee>> + Send;
 
     /// Gets a [`Header`] with the given hash.
     fn get_block_header(

--- a/src/types.rs
+++ b/src/types.rs
@@ -146,6 +146,25 @@ where
     }
 }
 
+/// Serializes the optional [`FeeRate`] into sat/vB.
+///
+/// Bitcoin Core's `fee_rate` option (e.g. for `walletcreatefundedpsbt` and `psbtbumpfee`) is
+/// expressed in sat/vB, while [`FeeRate`] stores its value internally in sat/kwu
+/// (250 sat/kwu = 1 sat/vB). Serializing the value as a fractional sat/vB number preserves
+/// sub-1 sat/vB fee rates.
+fn serialize_option_fee_rate<S>(
+    fee_rate: &Option<FeeRate>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match fee_rate {
+        Some(fr) => serializer.serialize_some(&(fr.to_sat_per_kwu() as f64 / 250.0)),
+        None => serializer.serialize_none(),
+    }
+}
+
 /// Deserializes the transaction id string into proper [`Txid`]s.
 fn deserialize_txid<'d, D>(deserializer: D) -> Result<Txid, D::Error>
 where
@@ -324,7 +343,10 @@ pub struct PsbtBumpFeeOptions {
     pub conf_target: Option<u16>,
 
     /// Fee rate in sat/vB.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_fee_rate"
+    )]
     pub fee_rate: Option<FeeRate>,
 
     /// Whether the new transaction should be BIP-125 replaceable.

--- a/src/types.rs
+++ b/src/types.rs
@@ -263,8 +263,13 @@ pub struct WalletCreateFundedPsbtOptions {
     ///
     /// If specified, this overrides the `conf_target` parameter for fee estimation.
     /// Must be a positive value representing the desired fee density.
-    #[serde(default, rename = "fee_rate", skip_serializing_if = "Option::is_none")]
-    pub fee_rate: Option<f64>,
+    #[serde(
+        default,
+        rename = "fee_rate",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_fee_rate"
+    )]
+    pub fee_rate: Option<FeeRate>,
 
     /// Whether to lock the selected UTXOs to prevent them from being spent by other transactions.
     ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -370,3 +370,113 @@ pub struct PsbtBumpFeeOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub original_change_index: Option<u32>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use serde_json::{json, Value};
+
+    #[derive(Serialize)]
+    struct FeeRateOption {
+        #[serde(serialize_with = "serialize_option_fee_rate")]
+        fee_rate: Option<FeeRate>,
+    }
+
+    const MAX_REASONABLE_FEE_RATE_SAT_PER_KWU: u64 = 1_000_000_000;
+
+    fn serialized_fee_rate_sat_per_kwu(value: &Value) -> u64 {
+        let fee_rate = value["fee_rate"].as_f64().unwrap();
+        (fee_rate * 250.0).round() as u64
+    }
+
+    proptest! {
+        #[test]
+        fn serialize_option_fee_rate_roundtrips_sat_per_kwu(
+            sat_per_kwu in 0u64..=MAX_REASONABLE_FEE_RATE_SAT_PER_KWU,
+        ) {
+            let value = serde_json::to_value(FeeRateOption {
+                fee_rate: Some(FeeRate::from_sat_per_kwu(sat_per_kwu)),
+            })
+            .unwrap();
+
+            prop_assert_eq!(serialized_fee_rate_sat_per_kwu(&value), sat_per_kwu);
+        }
+
+        #[test]
+        fn wallet_create_funded_psbt_options_roundtrips_fee_rate(
+            sat_per_kwu in 0u64..=MAX_REASONABLE_FEE_RATE_SAT_PER_KWU,
+        ) {
+            let value = serde_json::to_value(WalletCreateFundedPsbtOptions {
+                fee_rate: Some(FeeRate::from_sat_per_kwu(sat_per_kwu)),
+                ..Default::default()
+            })
+            .unwrap();
+
+            prop_assert_eq!(serialized_fee_rate_sat_per_kwu(&value), sat_per_kwu);
+        }
+
+        #[test]
+        fn psbt_bump_fee_options_roundtrips_fee_rate(
+            sat_per_kwu in 0u64..=MAX_REASONABLE_FEE_RATE_SAT_PER_KWU,
+        ) {
+            let value = serde_json::to_value(PsbtBumpFeeOptions {
+                fee_rate: Some(FeeRate::from_sat_per_kwu(sat_per_kwu)),
+                ..Default::default()
+            })
+            .unwrap();
+
+            prop_assert_eq!(serialized_fee_rate_sat_per_kwu(&value), sat_per_kwu);
+        }
+    }
+
+    #[test]
+    fn serialize_option_fee_rate_preserves_sub_sat_per_vb_example() {
+        let value = serde_json::to_value(FeeRateOption {
+            fee_rate: Some(FeeRate::from_sat_per_kwu(125)),
+        })
+        .unwrap();
+
+        assert_eq!(value, json!({ "fee_rate": 0.5 }));
+    }
+
+    #[test]
+    fn wallet_create_funded_psbt_options_serializes_fee_rate_as_sat_per_vb_example() {
+        let value = serde_json::to_value(WalletCreateFundedPsbtOptions {
+            fee_rate: Some(FeeRate::from_sat_per_kwu(375)),
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(value, json!({ "fee_rate": 1.5 }));
+    }
+
+    #[test]
+    fn wallet_create_funded_psbt_options_skips_missing_fee_rate() {
+        let value = serde_json::to_value(WalletCreateFundedPsbtOptions {
+            lock_unspents: Some(true),
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(value, json!({ "lockUnspents": true }));
+    }
+
+    #[test]
+    fn psbt_bump_fee_options_serializes_fee_rate_as_sat_per_vb_example() {
+        let value = serde_json::to_value(PsbtBumpFeeOptions {
+            fee_rate: Some(FeeRate::from_sat_per_vb(20).unwrap()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(value, json!({ "fee_rate": 20.0 }));
+    }
+
+    #[test]
+    fn serialize_option_fee_rate_serializes_none_as_null_without_skip() {
+        let value = serde_json::to_value(FeeRateOption { fee_rate: None }).unwrap();
+
+        assert_eq!(value, json!({ "fee_rate": Value::Null }));
+    }
+}


### PR DESCRIPTION
## Description

Preserves sub-1 sat/vB fee rates throughout the async client API.

Bitcoin Core returns fee estimates as fractional BTC/kvB values. The old `estimate_smart_fee` path converted those values into whole sat/vB integers, so positive sub-1 sat/vB estimates were truncated to `0`. This PR returns the shared `EstimateSmartFee` model with `bitcoin::FeeRate`, and serializes wallet fee-rate options as fractional sat/vB so low fee rates remain representable.

The changes are applied to both Bitcoin Core v29 and v30 client implementations after the v30 support rebase.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The public `Reader::estimate_smart_fee` return type changes from a whole sat/vB integer to `corepc_types::model::EstimateSmartFee`, which preserves sub-1 sat/vB values via `bitcoin::FeeRate` and keeps Bitcoin Core's `errors`/`blocks` fields available.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-2018.

Closes #69 

## Validation

- `cargo check --no-default-features --features 29_0 --tests`
- `cargo check --no-default-features --features 30_2 --tests`
- `RUSTFLAGS='-D warnings' cargo clippy --examples --tests --benches --no-default-features --features 29_0 --all-targets --locked`
- `RUSTFLAGS='-D warnings' cargo clippy --examples --tests --benches --no-default-features --features 30_2 --all-targets --locked`
- `cargo test --doc --no-default-features --features 29_0`
- `cargo test --doc --no-default-features --features 30_2`
