### PR TITLE
Make request logs debug level

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -184,7 +184,7 @@ impl Client {
     ) -> ClientResult<T> {
         let mut retries = 0;
         loop {
-            trace!(%method, ?params, %retries, "Calling bitcoin client");
+            debug!(%method, ?params, %retries, "Calling bitcoin client");
 
             let id = self.next_id();
 


### PR DESCRIPTION
Responses are often way larger than requests (raw blocks and txs). Being able to see requests and not responses is often very helpful for debugging. Most data is public anyway so responses can often be determined from replaying the request.

FWIW the bitcoincore-rpc crate also has this behavior: debug for requests and trace for responses.