### PR TITLE
feat!: support `maxburnamount` for broadcast RPCs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,7 +31,8 @@ jobs:
           cache-on-failure: true
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit --force --locked
+        # NOTE: version 0.22.1 is the latest compatible with MSRV 1.85
+        run: cargo install cargo-audit --force --locked --version "0.22.1"
 
       - name: Check for audit warnings
         run: cargo audit -D warnings

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,6 +12,7 @@ use std::{
 
 use crate::error::{BitcoinRpcError, ClientError};
 use base64::{engine::general_purpose, Engine};
+use bitcoin::{Amount, FeeRate};
 use bitreq::{post, Client as BitreqClient, Error as BitreqError};
 use serde::{de, Deserialize, Serialize};
 use serde_json::{json, value::Value};
@@ -51,6 +52,31 @@ where
 {
     serde_json::to_value(value)
         .map_err(|e| ClientError::Param(format!("Error creating value: {e}")))
+}
+
+pub(crate) fn push_broadcast_options(
+    params: &mut Vec<Value>,
+    max_fee_rate: Option<FeeRate>,
+    max_burn_amount: Option<Amount>,
+) -> ClientResult<()> {
+    if max_fee_rate.is_none() && max_burn_amount.is_none() {
+        return Ok(());
+    }
+
+    match max_fee_rate {
+        Some(max_fee_rate) => params.push(to_value(max_fee_rate_btc_per_kvb(max_fee_rate))?),
+        None => params.push(Value::Null),
+    }
+
+    if let Some(max_burn_amount) = max_burn_amount {
+        params.push(to_value(max_burn_amount.to_btc())?);
+    }
+
+    Ok(())
+}
+
+fn max_fee_rate_btc_per_kvb(max_fee_rate: FeeRate) -> f64 {
+    max_fee_rate.to_sat_per_kwu() as f64 / 25_000_000.0
 }
 
 /// The different authentication methods for the client.
@@ -319,6 +345,52 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn push_broadcast_options_omits_empty_options() {
+        let mut params = vec![json!("rawtx")];
+
+        push_broadcast_options(&mut params, None, None).unwrap();
+
+        assert_eq!(params, vec![json!("rawtx")]);
+    }
+
+    #[test]
+    fn push_broadcast_options_adds_max_fee_rate_only() {
+        let mut params = vec![json!("rawtx")];
+
+        push_broadcast_options(
+            &mut params,
+            Some(FeeRate::from_sat_per_kwu(25_000_000)),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(params, vec![json!("rawtx"), json!(1.0)]);
+    }
+
+    #[test]
+    fn push_broadcast_options_adds_null_placeholder_for_max_burn_amount_only() {
+        let mut params = vec![json!("rawtx")];
+
+        push_broadcast_options(&mut params, None, Some(Amount::from_sat(50_000))).unwrap();
+
+        assert_eq!(params, vec![json!("rawtx"), Value::Null, json!(0.0005)]);
+    }
+
+    #[test]
+    fn push_broadcast_options_adds_max_fee_rate_and_max_burn_amount() {
+        let mut params = vec![json!("rawtx")];
+
+        push_broadcast_options(
+            &mut params,
+            Some(FeeRate::from_sat_per_kwu(12_500_000)),
+            Some(Amount::from_sat(25_000)),
+        )
+        .unwrap();
+
+        assert_eq!(params, vec![json!("rawtx"), json!(0.5), json!(0.00025)]);
+    }
 
     async fn read_http_request(stream: &mut TcpStream) {
         let mut buf = vec![0u8; 4096];

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,7 +12,6 @@ use std::{
 
 use crate::error::{BitcoinRpcError, ClientError};
 use base64::{engine::general_purpose, Engine};
-use bitcoin::{Amount, FeeRate};
 use bitreq::{post, Client as BitreqClient, Error as BitreqError};
 use serde::{de, Deserialize, Serialize};
 use serde_json::{json, value::Value};
@@ -52,31 +51,6 @@ where
 {
     serde_json::to_value(value)
         .map_err(|e| ClientError::Param(format!("Error creating value: {e}")))
-}
-
-pub(crate) fn push_broadcast_options(
-    params: &mut Vec<Value>,
-    max_fee_rate: Option<FeeRate>,
-    max_burn_amount: Option<Amount>,
-) -> ClientResult<()> {
-    if max_fee_rate.is_none() && max_burn_amount.is_none() {
-        return Ok(());
-    }
-
-    match max_fee_rate {
-        Some(max_fee_rate) => params.push(to_value(max_fee_rate_btc_per_kvb(max_fee_rate))?),
-        None => params.push(Value::Null),
-    }
-
-    if let Some(max_burn_amount) = max_burn_amount {
-        params.push(to_value(max_burn_amount.to_btc())?);
-    }
-
-    Ok(())
-}
-
-fn max_fee_rate_btc_per_kvb(max_fee_rate: FeeRate) -> f64 {
-    max_fee_rate.to_sat_per_kwu() as f64 / 25_000_000.0
 }
 
 /// The different authentication methods for the client.
@@ -345,52 +319,6 @@ mod tests {
     };
 
     use super::*;
-
-    #[test]
-    fn push_broadcast_options_omits_empty_options() {
-        let mut params = vec![json!("rawtx")];
-
-        push_broadcast_options(&mut params, None, None).unwrap();
-
-        assert_eq!(params, vec![json!("rawtx")]);
-    }
-
-    #[test]
-    fn push_broadcast_options_adds_max_fee_rate_only() {
-        let mut params = vec![json!("rawtx")];
-
-        push_broadcast_options(
-            &mut params,
-            Some(FeeRate::from_sat_per_kwu(25_000_000)),
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(params, vec![json!("rawtx"), json!(1.0)]);
-    }
-
-    #[test]
-    fn push_broadcast_options_adds_null_placeholder_for_max_burn_amount_only() {
-        let mut params = vec![json!("rawtx")];
-
-        push_broadcast_options(&mut params, None, Some(Amount::from_sat(50_000))).unwrap();
-
-        assert_eq!(params, vec![json!("rawtx"), Value::Null, json!(0.0005)]);
-    }
-
-    #[test]
-    fn push_broadcast_options_adds_max_fee_rate_and_max_burn_amount() {
-        let mut params = vec![json!("rawtx")];
-
-        push_broadcast_options(
-            &mut params,
-            Some(FeeRate::from_sat_per_kwu(12_500_000)),
-            Some(Amount::from_sat(25_000)),
-        )
-        .unwrap();
-
-        assert_eq!(params, vec![json!("rawtx"), json!(0.5), json!(0.00025)]);
-    }
 
     async fn read_http_request(stream: &mut TcpStream) {
         let mut buf = vec![0u8; 4096];

--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -22,13 +22,13 @@ use tracing::*;
 use crate::{
     client::Client,
     error::ClientError,
-    push_broadcast_options, to_value,
+    to_value,
     traits::{Broadcaster, Reader, Signer, Wallet},
     types::{
-        CreateRawTransactionArguments, CreateRawTransactionInput, CreateRawTransactionOutput,
-        CreateWalletArguments, ImportDescriptorInput, ListUnspentQueryOptions,
-        PreviousTransactionOutput, PsbtBumpFeeOptions, SendRawTransactionOptions, SighashType,
-        SubmitPackageOptions, WalletCreateFundedPsbtOptions,
+        BroadcastOptions, CreateRawTransactionArguments, CreateRawTransactionInput,
+        CreateRawTransactionOutput, CreateWalletArguments, ImportDescriptorInput,
+        ListUnspentQueryOptions, PreviousTransactionOutput, PsbtBumpFeeOptions,
+        SendRawTransactionOptions, SighashType, WalletCreateFundedPsbtOptions,
     },
     ClientResult,
 };
@@ -197,7 +197,7 @@ impl Broadcaster for Client {
         trace!(txstr = %txstr, "Sending raw transaction");
         let mut params = vec![to_value(txstr)?];
         if let Some(options) = options {
-            push_broadcast_options(&mut params, options.max_fee_rate, options.max_burn_amount)?;
+            params.extend(options.to_params());
         }
 
         match self.call::<Txid>("sendrawtransaction", &params).await {
@@ -229,12 +229,12 @@ impl Broadcaster for Client {
     async fn submit_package(
         &self,
         txs: &[Transaction],
-        options: Option<SubmitPackageOptions>,
+        options: Option<BroadcastOptions>,
     ) -> ClientResult<model::SubmitPackage> {
         let txstrs: Vec<String> = txs.iter().map(serialize_hex).collect();
         let mut params = vec![to_value(txstrs)?];
         if let Some(options) = options {
-            push_broadcast_options(&mut params, options.max_fee_rate, options.max_burn_amount)?;
+            params.extend(options.to_params());
         }
 
         let resp = self.call::<SubmitPackage>("submitpackage", &params).await?;
@@ -495,10 +495,12 @@ mod test {
 
     use super::*;
     use crate::{
-        test_utils::corepc_node_helpers::{get_bitcoind_and_client, mine_blocks},
+        test_utils::corepc_node_helpers::{
+            assert_max_burn_amount_rejected, get_bitcoind_and_client, mine_blocks,
+        },
         types::{
-            CreateRawTransactionInput, CreateRawTransactionOutput, SendRawTransactionOptions,
-            SubmitPackageOptions,
+            BroadcastOptions, CreateRawTransactionInput, CreateRawTransactionOutput,
+            SendRawTransactionOptions,
         },
         Auth,
     };
@@ -970,10 +972,7 @@ mod test {
         let (signed_tx, burn_amount) = signed_op_return_burn_transaction(&bitcoind, &client).await;
 
         let rejected = client.send_raw_transaction(&signed_tx, None).await;
-        assert!(
-            rejected.is_err(),
-            "default maxburnamount should reject a nonzero OP_RETURN output"
-        );
+        assert_max_burn_amount_rejected(rejected, "sendrawtransaction");
 
         let txid = client
             .send_raw_transaction(
@@ -997,15 +996,12 @@ mod test {
         let (signed_tx, burn_amount) = signed_op_return_burn_transaction(&bitcoind, &client).await;
 
         let rejected = client.submit_package(&[signed_tx.clone()], None).await;
-        assert!(
-            rejected.is_err(),
-            "default maxburnamount should reject a package with a nonzero OP_RETURN output"
-        );
+        assert_max_burn_amount_rejected(rejected, "submitpackage");
 
         let result = client
             .submit_package(
                 &[signed_tx],
-                Some(SubmitPackageOptions {
+                Some(BroadcastOptions {
                     max_burn_amount: Some(burn_amount),
                     ..Default::default()
                 }),

--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -483,7 +483,10 @@ mod test {
 
     use std::{env, sync::Once, time::Duration};
 
-    use bitcoin::{hashes::Hash, transaction, Amount, FeeRate, NetworkKind};
+    use bitcoin::{
+        hashes::Hash, opcodes::all::OP_RETURN, script::Builder, transaction, Amount, FeeRate,
+        NetworkKind,
+    };
     use corepc_node::{Conf, Node, P2P};
     use corepc_types::v29::ImportDescriptorsResult;
     use serde_json::Value;
@@ -493,7 +496,7 @@ mod test {
     use super::*;
     use crate::{
         test_utils::corepc_node_helpers::{get_bitcoind_and_client, mine_blocks},
-        types::{CreateRawTransactionInput, CreateRawTransactionOutput},
+        types::{CreateRawTransactionInput, CreateRawTransactionOutput, SendRawTransactionOptions},
         Auth,
     };
 
@@ -910,6 +913,69 @@ mod test {
         assert_eq!(got.fee_rate, Some(FEE_ESTIMATION_FEE_RATE));
         assert!(got.errors.is_none());
         assert_eq!(got.blocks, 2);
+    }
+
+    #[tokio::test()]
+    async fn send_raw_transaction_accepts_explicit_max_burn_amount() {
+        init_tracing();
+
+        let (bitcoind, client) = get_bitcoind_and_client();
+
+        let blocks = mine_blocks(bitcoind, 101, None).unwrap();
+        let spendable_block = client.get_block(blocks.first().unwrap()).await.unwrap();
+        let coinbase_tx = spendable_block.coinbase().unwrap();
+
+        let burn_amount = Amount::from_sat(1_000);
+        let fee = Amount::from_sat(10_000);
+        let change_amount = COINBASE_AMOUNT - burn_amount - fee;
+        let burn_address = client.get_new_address().await.unwrap();
+        let change_address = client.get_new_address().await.unwrap();
+        let raw_tx = CreateRawTransactionArguments {
+            inputs: vec![CreateRawTransactionInput {
+                txid: coinbase_tx.compute_txid().to_string(),
+                vout: 0,
+            }],
+            outputs: vec![
+                CreateRawTransactionOutput::AddressAmount {
+                    address: burn_address.to_string(),
+                    amount: burn_amount.to_btc(),
+                },
+                CreateRawTransactionOutput::AddressAmount {
+                    address: change_address.to_string(),
+                    amount: change_amount.to_btc(),
+                },
+            ],
+        };
+        let mut tx = client.create_raw_transaction(raw_tx).await.unwrap();
+        tx.output[0].script_pubkey = Builder::new()
+            .push_opcode(OP_RETURN)
+            .push_slice([1u8; 32])
+            .into_script();
+
+        let signed_tx = client
+            .sign_raw_transaction_with_wallet(&tx, None)
+            .await
+            .unwrap()
+            .tx;
+
+        let rejected = client.send_raw_transaction(&signed_tx, None).await;
+        assert!(
+            rejected.is_err(),
+            "default maxburnamount should reject a nonzero OP_RETURN output"
+        );
+
+        let txid = client
+            .send_raw_transaction(
+                &signed_tx,
+                Some(SendRawTransactionOptions {
+                    max_burn_amount: Some(burn_amount),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(txid, signed_tx.compute_txid());
     }
 
     #[tokio::test()]

--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -22,12 +22,13 @@ use tracing::*;
 use crate::{
     client::Client,
     error::ClientError,
-    to_value,
+    push_broadcast_options, to_value,
     traits::{Broadcaster, Reader, Signer, Wallet},
     types::{
         CreateRawTransactionArguments, CreateRawTransactionInput, CreateRawTransactionOutput,
         CreateWalletArguments, ImportDescriptorInput, ListUnspentQueryOptions,
-        PreviousTransactionOutput, PsbtBumpFeeOptions, SighashType, WalletCreateFundedPsbtOptions,
+        PreviousTransactionOutput, PsbtBumpFeeOptions, SendRawTransactionOptions, SighashType,
+        SubmitPackageOptions, WalletCreateFundedPsbtOptions,
     },
     ClientResult,
 };
@@ -187,13 +188,19 @@ impl Reader for Client {
 }
 
 impl Broadcaster for Client {
-    async fn send_raw_transaction(&self, tx: &Transaction) -> ClientResult<Txid> {
+    async fn send_raw_transaction(
+        &self,
+        tx: &Transaction,
+        options: Option<SendRawTransactionOptions>,
+    ) -> ClientResult<Txid> {
         let txstr = serialize_hex(tx);
         trace!(txstr = %txstr, "Sending raw transaction");
-        match self
-            .call::<Txid>("sendrawtransaction", &[to_value(txstr)?])
-            .await
-        {
+        let mut params = vec![to_value(txstr)?];
+        if let Some(options) = options {
+            push_broadcast_options(&mut params, options.max_fee_rate, options.max_burn_amount)?;
+        }
+
+        match self.call::<Txid>("sendrawtransaction", &params).await {
             Ok(txid) => {
                 trace!(?txid, "Transaction sent");
                 Ok(txid)
@@ -219,11 +226,18 @@ impl Broadcaster for Client {
             .map_err(|e| ClientError::Parse(e.to_string()))
     }
 
-    async fn submit_package(&self, txs: &[Transaction]) -> ClientResult<model::SubmitPackage> {
+    async fn submit_package(
+        &self,
+        txs: &[Transaction],
+        options: Option<SubmitPackageOptions>,
+    ) -> ClientResult<model::SubmitPackage> {
         let txstrs: Vec<String> = txs.iter().map(serialize_hex).collect();
-        let resp = self
-            .call::<SubmitPackage>("submitpackage", &[to_value(txstrs)?])
-            .await?;
+        let mut params = vec![to_value(txstrs)?];
+        if let Some(options) = options {
+            push_broadcast_options(&mut params, options.max_fee_rate, options.max_burn_amount)?;
+        }
+
+        let resp = self.call::<SubmitPackage>("submitpackage", &params).await?;
         trace!(?resp, "Got submit package response");
 
         resp.into_model()
@@ -673,7 +687,7 @@ mod test {
 
         // get_transaction
         let tx = client.get_transaction(&txid).await.unwrap().tx;
-        let got = client.send_raw_transaction(&tx).await.unwrap();
+        let got = client.send_raw_transaction(&tx, None).await.unwrap();
         let expected = txid; // Don't touch this!
         assert_eq!(expected, got);
 
@@ -735,7 +749,7 @@ mod test {
         );
 
         // send_raw_transaction
-        let got = client.send_raw_transaction(&tx).await.unwrap();
+        let got = client.send_raw_transaction(&tx, None).await.unwrap();
         assert!(got.as_byte_array().len() == 32);
 
         // list_transactions
@@ -992,7 +1006,10 @@ mod test {
             .tx;
 
         // sanity check
-        let parent_submitted = client.send_raw_transaction(&signed_parent).await.unwrap();
+        let parent_submitted = client
+            .send_raw_transaction(&signed_parent, None)
+            .await
+            .unwrap();
 
         let child_raw_tx = CreateRawTransactionArguments {
             inputs: vec![CreateRawTransactionInput {
@@ -1016,7 +1033,7 @@ mod test {
 
         // Ok now we have a parent and a child transaction.
         let result = client
-            .submit_package(&[signed_parent, signed_child])
+            .submit_package(&[signed_parent, signed_child], None)
             .await
             .unwrap();
         assert_eq!(result.tx_results.len(), 2);
@@ -1067,7 +1084,7 @@ mod test {
         assert_eq!(signed_parent.version, transaction::Version(3));
 
         // Assert that the parent tx cannot be broadcasted.
-        let parent_broadcasted = client.send_raw_transaction(&signed_parent).await;
+        let parent_broadcasted = client.send_raw_transaction(&signed_parent, None).await;
         assert!(parent_broadcasted.is_err());
 
         // 5k sats as fees.
@@ -1102,12 +1119,12 @@ mod test {
         assert_eq!(signed_child.version, transaction::Version(3));
 
         // Assert that the child tx cannot be broadcasted.
-        let child_broadcasted = client.send_raw_transaction(&signed_child).await;
+        let child_broadcasted = client.send_raw_transaction(&signed_child, None).await;
         assert!(child_broadcasted.is_err());
 
         // Let's send as a package 1C1P.
         let result = client
-            .submit_package(&[signed_parent, signed_child])
+            .submit_package(&[signed_parent, signed_child], None)
             .await
             .unwrap();
         assert_eq!(result.tx_results.len(), 2);

--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -496,7 +496,10 @@ mod test {
     use super::*;
     use crate::{
         test_utils::corepc_node_helpers::{get_bitcoind_and_client, mine_blocks},
-        types::{CreateRawTransactionInput, CreateRawTransactionOutput, SendRawTransactionOptions},
+        types::{
+            CreateRawTransactionInput, CreateRawTransactionOutput, SendRawTransactionOptions,
+            SubmitPackageOptions,
+        },
         Auth,
     };
 
@@ -915,12 +918,10 @@ mod test {
         assert_eq!(got.blocks, 2);
     }
 
-    #[tokio::test()]
-    async fn send_raw_transaction_accepts_explicit_max_burn_amount() {
-        init_tracing();
-
-        let (bitcoind, client) = get_bitcoind_and_client();
-
+    async fn signed_op_return_burn_transaction(
+        bitcoind: &Node,
+        client: &Client,
+    ) -> (Transaction, Amount) {
         let blocks = mine_blocks(bitcoind, 101, None).unwrap();
         let spendable_block = client.get_block(blocks.first().unwrap()).await.unwrap();
         let coinbase_tx = spendable_block.coinbase().unwrap();
@@ -958,6 +959,16 @@ mod test {
             .unwrap()
             .tx;
 
+        (signed_tx, burn_amount)
+    }
+
+    #[tokio::test()]
+    async fn send_raw_transaction_accepts_explicit_max_burn_amount() {
+        init_tracing();
+
+        let (bitcoind, client) = get_bitcoind_and_client();
+        let (signed_tx, burn_amount) = signed_op_return_burn_transaction(&bitcoind, &client).await;
+
         let rejected = client.send_raw_transaction(&signed_tx, None).await;
         assert!(
             rejected.is_err(),
@@ -976,6 +987,34 @@ mod test {
             .unwrap();
 
         assert_eq!(txid, signed_tx.compute_txid());
+    }
+
+    #[tokio::test()]
+    async fn submit_package_accepts_explicit_max_burn_amount() {
+        init_tracing();
+
+        let (bitcoind, client) = get_bitcoind_and_client();
+        let (signed_tx, burn_amount) = signed_op_return_burn_transaction(&bitcoind, &client).await;
+
+        let rejected = client.submit_package(&[signed_tx.clone()], None).await;
+        assert!(
+            rejected.is_err(),
+            "default maxburnamount should reject a package with a nonzero OP_RETURN output"
+        );
+
+        let result = client
+            .submit_package(
+                &[signed_tx],
+                Some(SubmitPackageOptions {
+                    max_burn_amount: Some(burn_amount),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.package_msg, "success");
+        assert_eq!(result.tx_results.len(), 1);
     }
 
     #[tokio::test()]

--- a/src/client/v30.rs
+++ b/src/client/v30.rs
@@ -483,7 +483,10 @@ mod test {
 
     use std::{env, sync::Once, time::Duration};
 
-    use bitcoin::{hashes::Hash, transaction, Amount, FeeRate, NetworkKind};
+    use bitcoin::{
+        hashes::Hash, opcodes::all::OP_RETURN, script::Builder, transaction, Amount, FeeRate,
+        NetworkKind,
+    };
     use corepc_node::{Conf, Node, P2P};
     use corepc_types::v30::ImportDescriptorsResult;
     use serde_json::Value;
@@ -910,6 +913,69 @@ mod test {
         assert_eq!(got.fee_rate, Some(FEE_ESTIMATION_FEE_RATE));
         assert!(got.errors.is_none());
         assert_eq!(got.blocks, 2);
+    }
+
+    #[tokio::test()]
+    async fn send_raw_transaction_accepts_explicit_max_burn_amount() {
+        init_tracing();
+
+        let (bitcoind, client) = get_bitcoind_and_client();
+
+        let blocks = mine_blocks(bitcoind, 101, None).unwrap();
+        let spendable_block = client.get_block(blocks.first().unwrap()).await.unwrap();
+        let coinbase_tx = spendable_block.coinbase().unwrap();
+
+        let burn_amount = Amount::from_sat(1_000);
+        let fee = Amount::from_sat(10_000);
+        let change_amount = COINBASE_AMOUNT - burn_amount - fee;
+        let burn_address = client.get_new_address().await.unwrap();
+        let change_address = client.get_new_address().await.unwrap();
+        let raw_tx = CreateRawTransactionArguments {
+            inputs: vec![CreateRawTransactionInput {
+                txid: coinbase_tx.compute_txid().to_string(),
+                vout: 0,
+            }],
+            outputs: vec![
+                CreateRawTransactionOutput::AddressAmount {
+                    address: burn_address.to_string(),
+                    amount: burn_amount.to_btc(),
+                },
+                CreateRawTransactionOutput::AddressAmount {
+                    address: change_address.to_string(),
+                    amount: change_amount.to_btc(),
+                },
+            ],
+        };
+        let mut tx = client.create_raw_transaction(raw_tx).await.unwrap();
+        tx.output[0].script_pubkey = Builder::new()
+            .push_opcode(OP_RETURN)
+            .push_slice([1u8; 32])
+            .into_script();
+
+        let signed_tx = client
+            .sign_raw_transaction_with_wallet(&tx, None)
+            .await
+            .unwrap()
+            .tx;
+
+        let rejected = client.send_raw_transaction(&signed_tx, None).await;
+        assert!(
+            rejected.is_err(),
+            "default maxburnamount should reject a nonzero OP_RETURN output"
+        );
+
+        let txid = client
+            .send_raw_transaction(
+                &signed_tx,
+                Some(SendRawTransactionOptions {
+                    max_burn_amount: Some(burn_amount),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(txid, signed_tx.compute_txid());
     }
 
     #[tokio::test()]

--- a/src/client/v30.rs
+++ b/src/client/v30.rs
@@ -22,13 +22,13 @@ use tracing::*;
 use crate::{
     client::Client,
     error::ClientError,
-    push_broadcast_options, to_value,
+    to_value,
     traits::{Broadcaster, Reader, Signer, Wallet},
     types::{
-        CreateRawTransactionArguments, CreateRawTransactionInput, CreateRawTransactionOutput,
-        CreateWalletArguments, ImportDescriptorInput, ListUnspentQueryOptions,
-        PreviousTransactionOutput, PsbtBumpFeeOptions, SendRawTransactionOptions, SighashType,
-        SubmitPackageOptions, WalletCreateFundedPsbtOptions,
+        BroadcastOptions, CreateRawTransactionArguments, CreateRawTransactionInput,
+        CreateRawTransactionOutput, CreateWalletArguments, ImportDescriptorInput,
+        ListUnspentQueryOptions, PreviousTransactionOutput, PsbtBumpFeeOptions,
+        SendRawTransactionOptions, SighashType, WalletCreateFundedPsbtOptions,
     },
     ClientResult,
 };
@@ -197,7 +197,7 @@ impl Broadcaster for Client {
         trace!(txstr = %txstr, "Sending raw transaction");
         let mut params = vec![to_value(txstr)?];
         if let Some(options) = options {
-            push_broadcast_options(&mut params, options.max_fee_rate, options.max_burn_amount)?;
+            params.extend(options.to_params());
         }
 
         match self.call::<Txid>("sendrawtransaction", &params).await {
@@ -229,12 +229,12 @@ impl Broadcaster for Client {
     async fn submit_package(
         &self,
         txs: &[Transaction],
-        options: Option<SubmitPackageOptions>,
+        options: Option<BroadcastOptions>,
     ) -> ClientResult<model::SubmitPackage> {
         let txstrs: Vec<String> = txs.iter().map(serialize_hex).collect();
         let mut params = vec![to_value(txstrs)?];
         if let Some(options) = options {
-            push_broadcast_options(&mut params, options.max_fee_rate, options.max_burn_amount)?;
+            params.extend(options.to_params());
         }
 
         let resp = self.call::<SubmitPackage>("submitpackage", &params).await?;
@@ -495,10 +495,12 @@ mod test {
 
     use super::*;
     use crate::{
-        test_utils::corepc_node_helpers::{get_bitcoind_and_client, mine_blocks},
+        test_utils::corepc_node_helpers::{
+            assert_max_burn_amount_rejected, get_bitcoind_and_client, mine_blocks,
+        },
         types::{
-            CreateRawTransactionInput, CreateRawTransactionOutput, SendRawTransactionOptions,
-            SubmitPackageOptions,
+            BroadcastOptions, CreateRawTransactionInput, CreateRawTransactionOutput,
+            SendRawTransactionOptions,
         },
         Auth,
     };
@@ -970,10 +972,7 @@ mod test {
         let (signed_tx, burn_amount) = signed_op_return_burn_transaction(&bitcoind, &client).await;
 
         let rejected = client.send_raw_transaction(&signed_tx, None).await;
-        assert!(
-            rejected.is_err(),
-            "default maxburnamount should reject a nonzero OP_RETURN output"
-        );
+        assert_max_burn_amount_rejected(rejected, "sendrawtransaction");
 
         let txid = client
             .send_raw_transaction(
@@ -997,15 +996,12 @@ mod test {
         let (signed_tx, burn_amount) = signed_op_return_burn_transaction(&bitcoind, &client).await;
 
         let rejected = client.submit_package(&[signed_tx.clone()], None).await;
-        assert!(
-            rejected.is_err(),
-            "default maxburnamount should reject a package with a nonzero OP_RETURN output"
-        );
+        assert_max_burn_amount_rejected(rejected, "submitpackage");
 
         let result = client
             .submit_package(
                 &[signed_tx],
-                Some(SubmitPackageOptions {
+                Some(BroadcastOptions {
                     max_burn_amount: Some(burn_amount),
                     ..Default::default()
                 }),

--- a/src/client/v30.rs
+++ b/src/client/v30.rs
@@ -22,12 +22,13 @@ use tracing::*;
 use crate::{
     client::Client,
     error::ClientError,
-    to_value,
+    push_broadcast_options, to_value,
     traits::{Broadcaster, Reader, Signer, Wallet},
     types::{
         CreateRawTransactionArguments, CreateRawTransactionInput, CreateRawTransactionOutput,
         CreateWalletArguments, ImportDescriptorInput, ListUnspentQueryOptions,
-        PreviousTransactionOutput, PsbtBumpFeeOptions, SighashType, WalletCreateFundedPsbtOptions,
+        PreviousTransactionOutput, PsbtBumpFeeOptions, SendRawTransactionOptions, SighashType,
+        SubmitPackageOptions, WalletCreateFundedPsbtOptions,
     },
     ClientResult,
 };
@@ -187,13 +188,19 @@ impl Reader for Client {
 }
 
 impl Broadcaster for Client {
-    async fn send_raw_transaction(&self, tx: &Transaction) -> ClientResult<Txid> {
+    async fn send_raw_transaction(
+        &self,
+        tx: &Transaction,
+        options: Option<SendRawTransactionOptions>,
+    ) -> ClientResult<Txid> {
         let txstr = serialize_hex(tx);
         trace!(txstr = %txstr, "Sending raw transaction");
-        match self
-            .call::<Txid>("sendrawtransaction", &[to_value(txstr)?])
-            .await
-        {
+        let mut params = vec![to_value(txstr)?];
+        if let Some(options) = options {
+            push_broadcast_options(&mut params, options.max_fee_rate, options.max_burn_amount)?;
+        }
+
+        match self.call::<Txid>("sendrawtransaction", &params).await {
             Ok(txid) => {
                 trace!(?txid, "Transaction sent");
                 Ok(txid)
@@ -219,11 +226,18 @@ impl Broadcaster for Client {
             .map_err(|e| ClientError::Parse(e.to_string()))
     }
 
-    async fn submit_package(&self, txs: &[Transaction]) -> ClientResult<model::SubmitPackage> {
+    async fn submit_package(
+        &self,
+        txs: &[Transaction],
+        options: Option<SubmitPackageOptions>,
+    ) -> ClientResult<model::SubmitPackage> {
         let txstrs: Vec<String> = txs.iter().map(serialize_hex).collect();
-        let resp = self
-            .call::<SubmitPackage>("submitpackage", &[to_value(txstrs)?])
-            .await?;
+        let mut params = vec![to_value(txstrs)?];
+        if let Some(options) = options {
+            push_broadcast_options(&mut params, options.max_fee_rate, options.max_burn_amount)?;
+        }
+
+        let resp = self.call::<SubmitPackage>("submitpackage", &params).await?;
         trace!(?resp, "Got submit package response");
 
         resp.into_model()
@@ -479,7 +493,7 @@ mod test {
     use super::*;
     use crate::{
         test_utils::corepc_node_helpers::{get_bitcoind_and_client, mine_blocks},
-        types::{CreateRawTransactionInput, CreateRawTransactionOutput},
+        types::{CreateRawTransactionInput, CreateRawTransactionOutput, SendRawTransactionOptions},
         Auth,
     };
 
@@ -673,7 +687,7 @@ mod test {
 
         // get_transaction
         let tx = client.get_transaction(&txid).await.unwrap().tx;
-        let got = client.send_raw_transaction(&tx).await.unwrap();
+        let got = client.send_raw_transaction(&tx, None).await.unwrap();
         let expected = txid; // Don't touch this!
         assert_eq!(expected, got);
 
@@ -735,7 +749,7 @@ mod test {
         );
 
         // send_raw_transaction
-        let got = client.send_raw_transaction(&tx).await.unwrap();
+        let got = client.send_raw_transaction(&tx, None).await.unwrap();
         assert!(got.as_byte_array().len() == 32);
 
         // list_transactions
@@ -992,7 +1006,10 @@ mod test {
             .tx;
 
         // sanity check
-        let parent_submitted = client.send_raw_transaction(&signed_parent).await.unwrap();
+        let parent_submitted = client
+            .send_raw_transaction(&signed_parent, None)
+            .await
+            .unwrap();
 
         let child_raw_tx = CreateRawTransactionArguments {
             inputs: vec![CreateRawTransactionInput {
@@ -1016,7 +1033,7 @@ mod test {
 
         // Ok now we have a parent and a child transaction.
         let result = client
-            .submit_package(&[signed_parent, signed_child])
+            .submit_package(&[signed_parent, signed_child], None)
             .await
             .unwrap();
         assert_eq!(result.tx_results.len(), 2);
@@ -1067,7 +1084,7 @@ mod test {
         assert_eq!(signed_parent.version, transaction::Version(3));
 
         // Assert that the parent tx cannot be broadcasted.
-        let parent_broadcasted = client.send_raw_transaction(&signed_parent).await;
+        let parent_broadcasted = client.send_raw_transaction(&signed_parent, None).await;
         assert!(parent_broadcasted.is_err());
 
         // 5k sats as fees.
@@ -1102,12 +1119,12 @@ mod test {
         assert_eq!(signed_child.version, transaction::Version(3));
 
         // Assert that the child tx cannot be broadcasted.
-        let child_broadcasted = client.send_raw_transaction(&signed_child).await;
+        let child_broadcasted = client.send_raw_transaction(&signed_child, None).await;
         assert!(child_broadcasted.is_err());
 
         // Let's send as a package 1C1P.
         let result = client
-            .submit_package(&[signed_parent, signed_child])
+            .submit_package(&[signed_parent, signed_child], None)
             .await
             .unwrap();
         assert_eq!(result.tx_results.len(), 2);

--- a/src/client/v30.rs
+++ b/src/client/v30.rs
@@ -496,7 +496,10 @@ mod test {
     use super::*;
     use crate::{
         test_utils::corepc_node_helpers::{get_bitcoind_and_client, mine_blocks},
-        types::{CreateRawTransactionInput, CreateRawTransactionOutput, SendRawTransactionOptions},
+        types::{
+            CreateRawTransactionInput, CreateRawTransactionOutput, SendRawTransactionOptions,
+            SubmitPackageOptions,
+        },
         Auth,
     };
 
@@ -915,12 +918,10 @@ mod test {
         assert_eq!(got.blocks, 2);
     }
 
-    #[tokio::test()]
-    async fn send_raw_transaction_accepts_explicit_max_burn_amount() {
-        init_tracing();
-
-        let (bitcoind, client) = get_bitcoind_and_client();
-
+    async fn signed_op_return_burn_transaction(
+        bitcoind: &Node,
+        client: &Client,
+    ) -> (Transaction, Amount) {
         let blocks = mine_blocks(bitcoind, 101, None).unwrap();
         let spendable_block = client.get_block(blocks.first().unwrap()).await.unwrap();
         let coinbase_tx = spendable_block.coinbase().unwrap();
@@ -958,6 +959,16 @@ mod test {
             .unwrap()
             .tx;
 
+        (signed_tx, burn_amount)
+    }
+
+    #[tokio::test()]
+    async fn send_raw_transaction_accepts_explicit_max_burn_amount() {
+        init_tracing();
+
+        let (bitcoind, client) = get_bitcoind_and_client();
+        let (signed_tx, burn_amount) = signed_op_return_burn_transaction(&bitcoind, &client).await;
+
         let rejected = client.send_raw_transaction(&signed_tx, None).await;
         assert!(
             rejected.is_err(),
@@ -976,6 +987,34 @@ mod test {
             .unwrap();
 
         assert_eq!(txid, signed_tx.compute_txid());
+    }
+
+    #[tokio::test()]
+    async fn submit_package_accepts_explicit_max_burn_amount() {
+        init_tracing();
+
+        let (bitcoind, client) = get_bitcoind_and_client();
+        let (signed_tx, burn_amount) = signed_op_return_burn_transaction(&bitcoind, &client).await;
+
+        let rejected = client.submit_package(&[signed_tx.clone()], None).await;
+        assert!(
+            rejected.is_err(),
+            "default maxburnamount should reject a package with a nonzero OP_RETURN output"
+        );
+
+        let result = client
+            .submit_package(
+                &[signed_tx],
+                Some(SubmitPackageOptions {
+                    max_burn_amount: Some(burn_amount),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.package_msg, "success");
+        assert_eq!(result.tx_results.len(), 1);
     }
 
     #[tokio::test()]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -5,7 +5,7 @@ pub mod corepc_node_helpers {
     use bitcoin::{Address, BlockHash};
     use corepc_node::{Conf, Node};
 
-    use crate::{Auth, Client};
+    use crate::{error::ClientError, Auth, Client, ClientResult};
 
     /// Get the authentication credentials for a given `bitcoind` instance.
     fn get_auth(bitcoind: &Node) -> Auth {
@@ -45,5 +45,16 @@ pub mod corepc_node_helpers {
         let url = bitcoind.rpc_url();
         let client = Client::new(url, get_auth(&bitcoind), None, None, None).unwrap();
         (bitcoind, client)
+    }
+
+    pub fn assert_max_burn_amount_rejected<T>(result: ClientResult<T>, method: &str) {
+        match result {
+            Err(ClientError::Server(_, message)) => assert!(
+                message.contains("maxburnamount") || message.contains("max-burn-amount"),
+                "{method} should reject the default maxburnamount, got: {message}"
+            ),
+            Err(error) => panic!("{method} returned an unexpected error: {error:?}"),
+            Ok(_) => panic!("{method} unexpectedly accepted a nonzero OP_RETURN output"),
+        }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -167,6 +167,11 @@ pub trait Broadcaster {
     /// interface may be unstable. Refer to doc/policy/packages.md for documentation on package
     /// policies.
     ///
+    /// # Parameters
+    ///
+    /// - `txs`: The transactions to submit as a package.
+    /// - `options`: Optional package policy controls for maximum fee rate and burn amount.
+    ///
     /// # Warning
     ///
     /// Successful submission does not mean the transactions will propagate throughout the network.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,7 +13,7 @@ use crate::{
     types::{
         CreateRawTransactionArguments, CreateRawTransactionInput, CreateRawTransactionOutput,
         ListUnspentQueryOptions, PreviousTransactionOutput, PsbtBumpFeeOptions,
-        WalletCreateFundedPsbtOptions,
+        SendRawTransactionOptions, SubmitPackageOptions, WalletCreateFundedPsbtOptions,
     },
     ClientResult,
 };
@@ -147,9 +147,11 @@ pub trait Broadcaster {
     ///
     /// - `tx`: The raw transaction to send. This should be a byte array containing the serialized
     ///   raw transaction data.
+    /// - `options`: Optional broadcast policy controls for maximum fee rate and burn amount.
     fn send_raw_transaction(
         &self,
         tx: &Transaction,
+        options: Option<SendRawTransactionOptions>,
     ) -> impl Future<Output = ClientResult<Txid>> + Send;
 
     /// Tests if a raw transaction is valid.
@@ -171,6 +173,7 @@ pub trait Broadcaster {
     fn submit_package(
         &self,
         txs: &[Transaction],
+        options: Option<SubmitPackageOptions>,
     ) -> impl Future<Output = ClientResult<SubmitPackage>> + Send;
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,9 +11,9 @@ use std::future::Future;
 use crate::types::{ImportDescriptorInput, SighashType};
 use crate::{
     types::{
-        CreateRawTransactionArguments, CreateRawTransactionInput, CreateRawTransactionOutput,
-        ListUnspentQueryOptions, PreviousTransactionOutput, PsbtBumpFeeOptions,
-        SendRawTransactionOptions, SubmitPackageOptions, WalletCreateFundedPsbtOptions,
+        BroadcastOptions, CreateRawTransactionArguments, CreateRawTransactionInput,
+        CreateRawTransactionOutput, ListUnspentQueryOptions, PreviousTransactionOutput,
+        PsbtBumpFeeOptions, SendRawTransactionOptions, WalletCreateFundedPsbtOptions,
     },
     ClientResult,
 };
@@ -178,7 +178,7 @@ pub trait Broadcaster {
     fn submit_package(
         &self,
         txs: &[Transaction],
-        options: Option<SubmitPackageOptions>,
+        options: Option<BroadcastOptions>,
     ) -> impl Future<Output = ClientResult<SubmitPackage>> + Send;
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
+use serde_json::Value;
 
 /// Models the arguments of JSON-RPC method `createrawtransaction`.
 ///
@@ -135,33 +136,48 @@ pub struct CreateWalletArguments {
     pub load_on_startup: Option<bool>,
 }
 
+/// Shared options for transaction broadcast RPC methods.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BroadcastOptions {
+    /// Reject transactions whose fee rate is higher than this value.
+    ///
+    /// Bitcoin Core expects this value as BTC/kvB.
+    pub max_fee_rate: Option<FeeRate>,
+
+    /// Reject transactions whose provably unspendable outputs exceed this amount.
+    ///
+    /// Bitcoin Core expects this value as BTC.
+    pub max_burn_amount: Option<Amount>,
+}
+
+impl BroadcastOptions {
+    /// Converts these options to positional Bitcoin Core RPC parameters.
+    pub fn to_params(&self) -> impl IntoIterator<Item = Value> {
+        let mut params = Vec::new();
+
+        if self.max_fee_rate.is_none() && self.max_burn_amount.is_none() {
+            return params;
+        }
+
+        match self.max_fee_rate {
+            Some(max_fee_rate) => params.push(Value::from(max_fee_rate_btc_per_kvb(max_fee_rate))),
+            None => params.push(Value::Null),
+        }
+
+        if let Some(max_burn_amount) = self.max_burn_amount {
+            params.push(Value::from(max_burn_amount.to_btc()));
+        }
+
+        params
+    }
+}
+
+fn max_fee_rate_btc_per_kvb(max_fee_rate: FeeRate) -> f64 {
+    max_fee_rate.to_sat_per_kwu() as f64 / 25_000_000.0
+}
+
 /// Options for the `sendrawtransaction` RPC method.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct SendRawTransactionOptions {
-    /// Reject transactions whose fee rate is higher than this value.
-    ///
-    /// Bitcoin Core expects this value as BTC/kvB.
-    pub max_fee_rate: Option<FeeRate>,
-
-    /// Reject transactions whose provably unspendable outputs exceed this amount.
-    ///
-    /// Bitcoin Core expects this value as BTC.
-    pub max_burn_amount: Option<Amount>,
-}
-
-/// Options for the `submitpackage` RPC method.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct SubmitPackageOptions {
-    /// Reject transactions whose fee rate is higher than this value.
-    ///
-    /// Bitcoin Core expects this value as BTC/kvB.
-    pub max_fee_rate: Option<FeeRate>,
-
-    /// Reject transactions whose provably unspendable outputs exceed this amount.
-    ///
-    /// Bitcoin Core expects this value as BTC.
-    pub max_burn_amount: Option<Amount>,
-}
+pub type SendRawTransactionOptions = BroadcastOptions;
 
 /// Serializes the optional [`Amount`] into BTC.
 fn serialize_option_bitcoin<S>(amount: &Option<Amount>, serializer: S) -> Result<S::Ok, S::Error>
@@ -456,6 +472,55 @@ mod tests {
 
             prop_assert_eq!(serialized_fee_rate_sat_per_kwu(&value), sat_per_kwu);
         }
+    }
+
+    #[test]
+    fn broadcast_options_to_params_omits_empty_options() {
+        let params: Vec<_> = BroadcastOptions::default()
+            .to_params()
+            .into_iter()
+            .collect();
+
+        assert_eq!(params, Vec::<Value>::new());
+    }
+
+    #[test]
+    fn broadcast_options_to_params_adds_max_fee_rate_only() {
+        let params: Vec<_> = BroadcastOptions {
+            max_fee_rate: Some(FeeRate::from_sat_per_kwu(25_000_000)),
+            max_burn_amount: None,
+        }
+        .to_params()
+        .into_iter()
+        .collect();
+
+        assert_eq!(params, vec![json!(1.0)]);
+    }
+
+    #[test]
+    fn broadcast_options_to_params_adds_null_placeholder_for_max_burn_amount_only() {
+        let params: Vec<_> = BroadcastOptions {
+            max_fee_rate: None,
+            max_burn_amount: Some(Amount::from_sat(50_000)),
+        }
+        .to_params()
+        .into_iter()
+        .collect();
+
+        assert_eq!(params, vec![Value::Null, json!(0.0005)]);
+    }
+
+    #[test]
+    fn broadcast_options_to_params_adds_max_fee_rate_and_max_burn_amount() {
+        let params: Vec<_> = BroadcastOptions {
+            max_fee_rate: Some(FeeRate::from_sat_per_kwu(12_500_000)),
+            max_burn_amount: Some(Amount::from_sat(25_000)),
+        }
+        .to_params()
+        .into_iter()
+        .collect();
+
+        assert_eq!(params, vec![json!(0.5), json!(0.00025)]);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -135,6 +135,34 @@ pub struct CreateWalletArguments {
     pub load_on_startup: Option<bool>,
 }
 
+/// Options for the `sendrawtransaction` RPC method.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SendRawTransactionOptions {
+    /// Reject transactions whose fee rate is higher than this value.
+    ///
+    /// Bitcoin Core expects this value as BTC/kvB.
+    pub max_fee_rate: Option<FeeRate>,
+
+    /// Reject transactions whose provably unspendable outputs exceed this amount.
+    ///
+    /// Bitcoin Core expects this value as BTC.
+    pub max_burn_amount: Option<Amount>,
+}
+
+/// Options for the `submitpackage` RPC method.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SubmitPackageOptions {
+    /// Reject transactions whose fee rate is higher than this value.
+    ///
+    /// Bitcoin Core expects this value as BTC/kvB.
+    pub max_fee_rate: Option<FeeRate>,
+
+    /// Reject transactions whose provably unspendable outputs exceed this amount.
+    ///
+    /// Bitcoin Core expects this value as BTC.
+    pub max_burn_amount: Option<Amount>,
+}
+
 /// Serializes the optional [`Amount`] into BTC.
 fn serialize_option_bitcoin<S>(amount: &Option<Amount>, serializer: S) -> Result<S::Ok, S::Error>
 where


### PR DESCRIPTION
## Description

Adds optional broadcast controls for `sendrawtransaction` and `submitpackage`, including support for Bitcoin Core's `maxburnamount` argument. This lets callers intentionally broadcast transactions/packages with nonzero provably-unspendable outputs, such as `OP_RETURN` burns.

This is a breaking API change: `send_raw_transaction` and `submit_package` now take optional options structs.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

`maxburnamount` is the third positional argument for both RPCs, after `maxfeerate`. When only `max_burn_amount` is provided, this PR passes `null` for `maxfeerate` so Bitcoin Core uses its default.

The node-backed tests cover both v29 and v30 for `sendrawtransaction` and `submitpackage`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-3070