### PR TITLE
feat!: add Wallet::send for native anti-fee-sniping

### DIFF
--- a/src/client/v29.rs
+++ b/src/client/v29.rs
@@ -17,6 +17,7 @@ use corepc_types::v29::{
     SignRawTransactionWithWallet, SubmitPackage, TestMempoolAccept, WalletCreateFundedPsbt,
     WalletProcessPsbt,
 };
+use serde_json::Value;
 use tracing::*;
 
 use crate::{
@@ -27,7 +28,7 @@ use crate::{
     types::{
         BroadcastOptions, CreateRawTransactionArguments, CreateRawTransactionInput,
         CreateRawTransactionOutput, CreateWalletArguments, ImportDescriptorInput,
-        ListUnspentQueryOptions, PreviousTransactionOutput, PsbtBumpFeeOptions,
+        ListUnspentQueryOptions, PreviousTransactionOutput, PsbtBumpFeeOptions, SendOptions,
         SendRawTransactionOptions, SighashType, WalletCreateFundedPsbtOptions,
     },
     ClientResult,
@@ -311,6 +312,27 @@ impl Wallet for Client {
                     to_value(locktime.unwrap_or(0))?,
                     to_value(options.unwrap_or_default())?,
                     to_value(bip32_derivs)?,
+                ],
+            )
+            .await?;
+        resp.into_model()
+            .map_err(|e| ClientError::Parse(e.to_string()))
+    }
+
+    async fn send(
+        &self,
+        outputs: &[CreateRawTransactionOutput],
+        options: Option<SendOptions>,
+    ) -> ClientResult<model::Send> {
+        let resp = self
+            .call::<corepc_types::v29::Send>(
+                "send",
+                &[
+                    to_value(outputs)?,
+                    Value::Null,
+                    Value::Null,
+                    Value::Null,
+                    to_value(options.unwrap_or_default())?,
                 ],
             )
             .await?;
@@ -1378,6 +1400,46 @@ mod test {
             got, signed_txid,
             "Bumped transaction should be accepted in mempool"
         );
+    }
+
+    #[tokio::test]
+    async fn send_returns_signed_psbt_with_zero_locktime() {
+        init_tracing();
+
+        let (bitcoind, client) = get_bitcoind_and_client();
+
+        mine_blocks(&bitcoind, 101, None).unwrap();
+
+        let destination = client.get_new_address().await.unwrap();
+        let outputs = vec![CreateRawTransactionOutput::AddressAmount {
+            address: destination.to_string(),
+            amount: 1.0,
+        }];
+
+        let options = SendOptions {
+            add_to_wallet: Some(false),
+            fee_rate: Some(FeeRate::from_sat_per_vb(2).unwrap()),
+            lock_unspents: Some(true),
+        };
+        let result = client.send(&outputs, Some(options)).await.unwrap();
+
+        assert!(result.complete, "single-sig wallet should fully sign");
+        let psbt = result.psbt.expect("add_to_wallet=false returns a PSBT");
+
+        // v29's `send` does not apply anti-fee-sniping; the nLockTime defaults to 0.
+        let locktime = psbt.unsigned_tx.lock_time.to_consensus_u32();
+        assert_eq!(locktime, 0, "v29 send should default nLockTime to 0");
+
+        let signed_tx = psbt.extract_tx().unwrap();
+        let signed_txid = signed_tx.compute_txid();
+        let acceptance = client.test_mempool_accept(&signed_tx).await.unwrap();
+        let result = acceptance.results.first().unwrap();
+        assert!(
+            result.allowed,
+            "signed tx from send's PSBT should be accepted: {:?}",
+            result.reject_reason
+        );
+        assert_eq!(result.txid, signed_txid);
     }
 
     #[cfg(feature = "raw_rpc")]

--- a/src/client/v30.rs
+++ b/src/client/v30.rs
@@ -17,6 +17,7 @@ use corepc_types::v30::{
     SignRawTransactionWithWallet, SubmitPackage, TestMempoolAccept, WalletCreateFundedPsbt,
     WalletProcessPsbt,
 };
+use serde_json::Value;
 use tracing::*;
 
 use crate::{
@@ -27,7 +28,7 @@ use crate::{
     types::{
         BroadcastOptions, CreateRawTransactionArguments, CreateRawTransactionInput,
         CreateRawTransactionOutput, CreateWalletArguments, ImportDescriptorInput,
-        ListUnspentQueryOptions, PreviousTransactionOutput, PsbtBumpFeeOptions,
+        ListUnspentQueryOptions, PreviousTransactionOutput, PsbtBumpFeeOptions, SendOptions,
         SendRawTransactionOptions, SighashType, WalletCreateFundedPsbtOptions,
     },
     ClientResult,
@@ -311,6 +312,27 @@ impl Wallet for Client {
                     to_value(locktime.unwrap_or(0))?,
                     to_value(options.unwrap_or_default())?,
                     to_value(bip32_derivs)?,
+                ],
+            )
+            .await?;
+        resp.into_model()
+            .map_err(|e| ClientError::Parse(e.to_string()))
+    }
+
+    async fn send(
+        &self,
+        outputs: &[CreateRawTransactionOutput],
+        options: Option<SendOptions>,
+    ) -> ClientResult<model::Send> {
+        let resp = self
+            .call::<corepc_types::v30::Send>(
+                "send",
+                &[
+                    to_value(outputs)?,
+                    Value::Null,
+                    Value::Null,
+                    Value::Null,
+                    to_value(options.unwrap_or_default())?,
                 ],
             )
             .await?;
@@ -1378,6 +1400,51 @@ mod test {
             got, signed_txid,
             "Bumped transaction should be accepted in mempool"
         );
+    }
+
+    #[tokio::test]
+    async fn send_returns_signed_psbt_with_anti_fee_sniping_locktime() {
+        init_tracing();
+
+        let (bitcoind, client) = get_bitcoind_and_client();
+
+        mine_blocks(&bitcoind, 101, None).unwrap();
+        let tip = client.get_block_count().await.unwrap();
+
+        let destination = client.get_new_address().await.unwrap();
+        let outputs = vec![CreateRawTransactionOutput::AddressAmount {
+            address: destination.to_string(),
+            amount: 1.0,
+        }];
+
+        let options = SendOptions {
+            add_to_wallet: Some(false),
+            fee_rate: Some(FeeRate::from_sat_per_vb(2).unwrap()),
+            lock_unspents: Some(true),
+        };
+        let result = client.send(&outputs, Some(options)).await.unwrap();
+
+        assert!(result.complete, "single-sig wallet should fully sign");
+        let psbt = result.psbt.expect("add_to_wallet=false returns a PSBT");
+
+        // Anti-fee-sniping: Core picks an nLockTime in [tip-100, tip], not the exact tip.
+        let locktime = psbt.unsigned_tx.lock_time.to_consensus_u32() as u64;
+        assert!(
+            locktime <= tip && locktime >= tip.saturating_sub(100),
+            "nLockTime {locktime} should be in [{}, {tip}]",
+            tip.saturating_sub(100)
+        );
+
+        let signed_tx = psbt.extract_tx().unwrap();
+        let signed_txid = signed_tx.compute_txid();
+        let acceptance = client.test_mempool_accept(&signed_tx).await.unwrap();
+        let result = acceptance.results.first().unwrap();
+        assert!(
+            result.allowed,
+            "signed tx from send's PSBT should be accepted: {:?}",
+            result.reject_reason
+        );
+        assert_eq!(result.txid, signed_txid);
     }
 
     #[cfg(feature = "raw_rpc")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,7 +13,7 @@ use crate::{
     types::{
         BroadcastOptions, CreateRawTransactionArguments, CreateRawTransactionInput,
         CreateRawTransactionOutput, ListUnspentQueryOptions, PreviousTransactionOutput,
-        PsbtBumpFeeOptions, SendRawTransactionOptions, WalletCreateFundedPsbtOptions,
+        PsbtBumpFeeOptions, SendOptions, SendRawTransactionOptions, WalletCreateFundedPsbtOptions,
     },
     ClientResult,
 };
@@ -260,6 +260,19 @@ pub trait Wallet {
         options: Option<WalletCreateFundedPsbtOptions>,
         bip32_derivs: Option<bool>,
     ) -> impl Future<Output = ClientResult<WalletCreateFundedPsbt>> + Send;
+
+    /// Funds, signs, and optionally broadcasts a transaction via Bitcoin Core's `send` RPC.
+    ///
+    /// Unlike [`wallet_create_funded_psbt`](Self::wallet_create_funded_psbt), `send` lets Core
+    /// set the `nLockTime`. Core v30 and newer default to an anti-fee-sniping `nLockTime` near the
+    /// current block height, whereas v29 defaults to `0`.
+    ///
+    /// With `add_to_wallet = false` it returns the signed PSBT without broadcasting.
+    fn send(
+        &self,
+        outputs: &[CreateRawTransactionOutput],
+        options: Option<SendOptions>,
+    ) -> impl Future<Output = ClientResult<corepc_types::model::Send>> + Send;
 
     /// Returns detailed information about the given address.
     ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -350,6 +350,43 @@ pub struct WalletCreateFundedPsbtOptions {
     pub replaceable: Option<bool>,
 }
 
+/// Options for sending transactions with the wallet.
+///
+/// Used with [`Wallet::send`](crate::traits::Wallet::send) to fund, sign, and optionally
+/// broadcast a transaction via Bitcoin Core's `send` RPC.
+///
+/// # Note
+///
+/// All fields are optional and will use Bitcoin Core defaults if not specified.
+#[derive(Clone, Debug, PartialEq, Serialize, Default)]
+pub struct SendOptions {
+    /// Add the transaction to the wallet and broadcast it. When `false`, `send` returns
+    /// the signed PSBT without broadcasting. Default is `true`.
+    #[serde(
+        default,
+        rename = "add_to_wallet",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub add_to_wallet: Option<bool>,
+
+    /// Fee rate in sat/vB.
+    #[serde(
+        default,
+        rename = "fee_rate",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_fee_rate"
+    )]
+    pub fee_rate: Option<FeeRate>,
+
+    /// Lock the selected UTXOs. Note: `send` expects `lock_unspents`, not `lockUnspents`.
+    #[serde(
+        default,
+        rename = "lock_unspents",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub lock_unspents: Option<bool>,
+}
+
 /// Query options for filtering unspent transaction outputs.
 ///
 /// Used with `list_unspent` to apply additional filtering criteria
@@ -472,6 +509,19 @@ mod tests {
 
             prop_assert_eq!(serialized_fee_rate_sat_per_kwu(&value), sat_per_kwu);
         }
+
+        #[test]
+        fn send_options_roundtrips_fee_rate(
+            sat_per_kwu in 0u64..=MAX_REASONABLE_FEE_RATE_SAT_PER_KWU,
+        ) {
+            let value = serde_json::to_value(SendOptions {
+                fee_rate: Some(FeeRate::from_sat_per_kwu(sat_per_kwu)),
+                ..Default::default()
+            })
+            .unwrap();
+
+            prop_assert_eq!(serialized_fee_rate_sat_per_kwu(&value), sat_per_kwu);
+        }
     }
 
     #[test]
@@ -564,6 +614,32 @@ mod tests {
         .unwrap();
 
         assert_eq!(value, json!({ "fee_rate": 20.0 }));
+    }
+
+    #[test]
+    fn send_options_serializes_fields_example() {
+        let value = serde_json::to_value(SendOptions {
+            add_to_wallet: Some(false),
+            fee_rate: Some(FeeRate::from_sat_per_vb(2).unwrap()),
+            lock_unspents: Some(true),
+        })
+        .unwrap();
+
+        assert_eq!(
+            value,
+            json!({ "add_to_wallet": false, "fee_rate": 2.0, "lock_unspents": true })
+        );
+    }
+
+    #[test]
+    fn send_options_skips_missing_fields() {
+        let value = serde_json::to_value(SendOptions {
+            add_to_wallet: Some(false),
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(value, json!({ "add_to_wallet": false }));
     }
 
     #[test]


### PR DESCRIPTION
adds `Wallet::send` (Core's `send` RPC) for the v29/v30 clients.

`wallet_create_funded_psbt` can't produce Core's anti-fee-sniping `nLockTime` (its funding path always sets `coin_control.m_locktime`); `send` does. With `add_to_wallet=false` it returns the signed PSBT without broadcasting.

tested: regtest (`nLockTime` in [tip-100, tip], finalizable + mempool-accepted) and `SendOptions` serialization.
 
BREAKING: adds a required method to the public `Wallet` trait

closes #125 