### PR TITLE
fix: reject unbounded f64 raw transaction amounts

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -56,7 +56,7 @@ impl Serialize for CreateRawTransactionOutput {
             CreateRawTransactionOutput::AddressAmount { address, amount } => {
                 let mut map = serde_json::Map::new();
                 let amount = serde_json::Number::from_f64(*amount)
-                    .ok_or_else(|| serde::ser::Error::custom("amount must be finite"))?;
+                    .ok_or_else(|| serde::ser::Error::custom("amount must fit in a f64"))?;
                 map.insert(address.clone(), serde_json::Value::Number(amount));
                 map.serialize(serializer)
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,10 +55,9 @@ impl Serialize for CreateRawTransactionOutput {
         match self {
             CreateRawTransactionOutput::AddressAmount { address, amount } => {
                 let mut map = serde_json::Map::new();
-                map.insert(
-                    address.clone(),
-                    serde_json::Value::Number(serde_json::Number::from_f64(*amount).unwrap()),
-                );
+                let amount = serde_json::Number::from_f64(*amount)
+                    .ok_or_else(|| serde::ser::Error::custom("amount must be finite"))?;
+                map.insert(address.clone(), serde_json::Value::Number(amount));
                 map.serialize(serializer)
             }
             CreateRawTransactionOutput::Data { data } => {
@@ -522,6 +521,17 @@ mod tests {
 
             prop_assert_eq!(serialized_fee_rate_sat_per_kwu(&value), sat_per_kwu);
         }
+    }
+
+    #[test]
+    fn create_raw_transaction_output_rejects_nonfinite_amounts() {
+        let output = CreateRawTransactionOutput::AddressAmount {
+            address: "bcrt1qtest".to_string(),
+            amount: f64::NAN,
+        };
+
+        let err = serde_json::to_value(output).unwrap_err();
+        assert!(err.to_string().contains("amount must be finite"));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -531,7 +531,7 @@ mod tests {
         };
 
         let err = serde_json::to_value(output).unwrap_err();
-        assert!(err.to_string().contains("amount must be finite"));
+        assert!(err.to_string().contains("amount must fit in a f64"));
     }
 
     #[test]


### PR DESCRIPTION
`CreateRawTransactionOutput` serialized address amounts with `Number::from_f64(...).unwrap()`. If a caller passed a nonfinite value such as `NaN`, serialization could panic.

This returns a serialization error for nonfinite output amounts instead and adds regression coverage.